### PR TITLE
changes pyplot to use interactive mode so .show() won't block

### DIFF
--- a/discovery/alpha_vantage_api.py
+++ b/discovery/alpha_vantage_api.py
@@ -25,5 +25,5 @@ def sectors(l_args):
     plt.title('Real Time Performance (%) per Sector')
     plt.tight_layout()
     plt.grid()
-    plt.show()
+    plt.show(block=False)
     print("")

--- a/discovery/alpha_vantage_api.py
+++ b/discovery/alpha_vantage_api.py
@@ -25,5 +25,6 @@ def sectors(l_args):
     plt.title('Real Time Performance (%) per Sector')
     plt.tight_layout()
     plt.grid()
-    plt.show(block=False)
+    plt.ion()
+    plt.show()
     print("")

--- a/due_diligence/business_insider_api.py
+++ b/due_diligence/business_insider_api.py
@@ -51,6 +51,8 @@ def price_target_from_analysts(l_args, df_stock, s_ticker, s_start, s_interval):
         df_analyst_data['Date'] = pd.to_datetime(df_analyst_data['Date'])
         df_analyst_data = df_analyst_data.set_index('Date')
 
+        plt.figure()
+
         # Slice start of ratings
         if s_start:
             df_analyst_data = df_analyst_data[s_start:]

--- a/due_diligence/business_insider_api.py
+++ b/due_diligence/business_insider_api.py
@@ -77,7 +77,7 @@ def price_target_from_analysts(l_args, df_stock, s_ticker, s_start, s_interval):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.minorticks_on()
         plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-        plt.show()
+        plt.show(block=False)
         print("")
 
         pd.set_option('display.max_colwidth', -1)
@@ -303,7 +303,7 @@ def insider_activity(l_args, df_stock, s_ticker, s_start, s_interval):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.minorticks_on()
         plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-        plt.show()
+        plt.show(block=False)
 
         l_names = list()
         for s_name in text_soup_market_business_insider.findAll('a', {'onclick':"silentTrackPI()"}):

--- a/due_diligence/business_insider_api.py
+++ b/due_diligence/business_insider_api.py
@@ -77,7 +77,8 @@ def price_target_from_analysts(l_args, df_stock, s_ticker, s_start, s_interval):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.minorticks_on()
         plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
         print("")
 
         pd.set_option('display.max_colwidth', -1)
@@ -303,7 +304,8 @@ def insider_activity(l_args, df_stock, s_ticker, s_start, s_interval):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.minorticks_on()
         plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         l_names = list()
         for s_name in text_soup_market_business_insider.findAll('a', {'onclick':"silentTrackPI()"}):

--- a/due_diligence/business_insider_api.py
+++ b/due_diligence/business_insider_api.py
@@ -51,11 +51,12 @@ def price_target_from_analysts(l_args, df_stock, s_ticker, s_start, s_interval):
         df_analyst_data['Date'] = pd.to_datetime(df_analyst_data['Date'])
         df_analyst_data = df_analyst_data.set_index('Date')
 
-        plt.figure()
 
         # Slice start of ratings
         if s_start:
             df_analyst_data = df_analyst_data[s_start:]
+
+        plt.figure()
 
         if s_interval == "1440min":
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, lw=3)

--- a/due_diligence/quandl_api.py
+++ b/due_diligence/quandl_api.py
@@ -66,7 +66,7 @@ def short_interest(l_args, s_ticker, s_start):
         print(df_short_interest.head(n=ns_parser.n_days).to_string())
         print("")
 
-        plt.show()
+        plt.show(block=False)
 
     except:
         print("")

--- a/due_diligence/quandl_api.py
+++ b/due_diligence/quandl_api.py
@@ -66,7 +66,8 @@ def short_interest(l_args, s_ticker, s_start):
         print(df_short_interest.head(n=ns_parser.n_days).to_string())
         print("")
 
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
     except:
         print("")

--- a/helper_funcs.py
+++ b/helper_funcs.py
@@ -53,7 +53,8 @@ def plot_view_stock(df, symbol):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show(block=False)
+    plt.ion()
+    plt.show()
     print("")
 
 
@@ -76,7 +77,8 @@ def plot_stock_ta(df_stock, s_ticker, df_ta, s_ta):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show(block=False)
+    plt.ion()
+    plt.show()
     print("")
 
 
@@ -103,7 +105,8 @@ def plot_stock_and_ta(df_stock, s_ticker, df_ta, s_ta):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show(block=False)
+    plt.ion()
+    plt.show()
     print("")
 
 
@@ -119,7 +122,8 @@ def plot_ta(s_ticker, df_ta, s_ta):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show(block=False)
+    plt.ion()
+    plt.show()
     print("")
 
 

--- a/helper_funcs.py
+++ b/helper_funcs.py
@@ -53,7 +53,7 @@ def plot_view_stock(df, symbol):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show()
+    plt.show(block=False)
     print("")
 
 
@@ -76,7 +76,7 @@ def plot_stock_ta(df_stock, s_ticker, df_ta, s_ta):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show()
+    plt.show(block=False)
     print("")
 
 
@@ -103,7 +103,7 @@ def plot_stock_and_ta(df_stock, s_ticker, df_ta, s_ta):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show()
+    plt.show(block=False)
     print("")
 
 
@@ -119,7 +119,7 @@ def plot_ta(s_ticker, df_ta, s_ta):
     plt.grid(b=True, which='major', color='#666666', linestyle='-')
     plt.minorticks_on()
     plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-    plt.show()
+    plt.show(block=False)
     print("")
 
 

--- a/prediction_techniques/arima.py
+++ b/prediction_techniques/arima.py
@@ -75,7 +75,8 @@ def arima(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/arima.py
+++ b/prediction_techniques/arima.py
@@ -75,7 +75,7 @@ def arima(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/arima.py
+++ b/prediction_techniques/arima.py
@@ -59,6 +59,7 @@ def arima(l_args, s_ticker, s_interval, df_stock):
             print("")
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=2)
         if ns_parser.s_order:
             plt.title(f"ARIMA {str(t_order)} on {s_ticker} - {ns_parser.n_days} days prediction")

--- a/prediction_techniques/fbprophet.py
+++ b/prediction_techniques/fbprophet.py
@@ -49,7 +49,8 @@ def fbprophet(l_args, s_ticker, s_interval, df_stock):
         plt.ylim(ymin, ymax)
         plt.xlim(df_stock['ds'].values[0], get_next_stock_market_days(l_pred_days[-1], 1)[-1])
         plt.title(f"Fb Prophet on {s_ticker} - {ns_parser.n_days} days prediction")
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         print("")
         print("Predicted share price:")

--- a/prediction_techniques/fbprophet.py
+++ b/prediction_techniques/fbprophet.py
@@ -49,7 +49,7 @@ def fbprophet(l_args, s_ticker, s_interval, df_stock):
         plt.ylim(ymin, ymax)
         plt.xlim(df_stock['ds'].values[0], get_next_stock_market_days(l_pred_days[-1], 1)[-1])
         plt.title(f"Fb Prophet on {s_ticker} - {ns_parser.n_days} days prediction")
-        plt.show()
+        plt.show(block=False)
 
         print("")
         print("Predicted share price:")

--- a/prediction_techniques/knn.py
+++ b/prediction_techniques/knn.py
@@ -57,7 +57,8 @@ def k_nearest_neighbors(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/knn.py
+++ b/prediction_techniques/knn.py
@@ -57,7 +57,7 @@ def k_nearest_neighbors(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/knn.py
+++ b/prediction_techniques/knn.py
@@ -11,17 +11,17 @@ from TimeSeriesCrossValidation import splitTrain
 # ----------------------------------------------------- kNN -----------------------------------------------------
 def k_nearest_neighbors(l_args, s_ticker, s_interval, df_stock):
     parser = argparse.ArgumentParser(prog='knn',
-                                     description=""" K nearest neighbors is a simple algorithm that stores all 
-                                     available cases and predict the numerical target based on a similarity measure 
+                                     description=""" K nearest neighbors is a simple algorithm that stores all
+                                     available cases and predict the numerical target based on a similarity measure
                                      (e.g. distance functions). """)
 
-    parser.add_argument('-i', "--input", action="store", dest="n_inputs", type=check_positive, default=40, 
+    parser.add_argument('-i', "--input", action="store", dest="n_inputs", type=check_positive, default=40,
                         help='number of days to use for prediction.')
-    parser.add_argument('-d', "--days", action="store", dest="n_days", type=check_positive, default=5, 
+    parser.add_argument('-d', "--days", action="store", dest="n_days", type=check_positive, default=5,
                         help='prediction days.')
-    parser.add_argument('-j', "--jumps", action="store", dest="n_jumps", type=check_positive, default=1, 
+    parser.add_argument('-j', "--jumps", action="store", dest="n_jumps", type=check_positive, default=1,
                         help='number of jumps in training data.')
-    parser.add_argument('-n', "--neighbors", action="store", dest="n_neighbors", type=check_positive, default=20, 
+    parser.add_argument('-n', "--neighbors", action="store", dest="n_neighbors", type=check_positive, default=20,
                         help='number of neighbors to use on the algorithm.')
 
     try:
@@ -41,9 +41,10 @@ def k_nearest_neighbors(l_args, s_ticker, s_interval, df_stock):
         # Prediction data
         l_predictions = knn.predict(df_stock['5. adjusted close'].values[-ns_parser.n_inputs:].reshape(1, -1))[0]
         l_pred_days = get_next_stock_market_days(last_stock_day=df_stock['5. adjusted close'].index[-1], n_next_days=ns_parser.n_days)
-        df_pred = pd.Series(l_predictions, index=l_pred_days, name='Price') 
+        df_pred = pd.Series(l_predictions, index=l_pred_days, name='Price')
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=2)
         plt.title(f"{ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1])

--- a/prediction_techniques/neural_networks.py
+++ b/prediction_techniques/neural_networks.py
@@ -150,7 +150,7 @@ def mlp(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, colors='k', linewidth=3, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")
@@ -243,7 +243,7 @@ def rnn(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, colors='k', linewidth=3, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")
@@ -336,7 +336,7 @@ def lstm(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, colors='k', linewidth=3, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/neural_networks.py
+++ b/prediction_techniques/neural_networks.py
@@ -150,7 +150,8 @@ def mlp(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, colors='k', linewidth=3, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")
@@ -243,7 +244,8 @@ def rnn(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, colors='k', linewidth=3, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")
@@ -336,7 +338,8 @@ def lstm(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, colors='k', linewidth=3, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/neural_networks.py
+++ b/prediction_techniques/neural_networks.py
@@ -137,6 +137,7 @@ def mlp(l_args, s_ticker, s_interval, df_stock):
         df_pred = pd.Series(y_pred_test_t[0].tolist(), index=l_pred_days, name='Price') 
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=3)
         plt.title(f"MLP on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1])
@@ -231,6 +232,7 @@ def rnn(l_args, s_ticker, s_interval, df_stock):
         df_pred = pd.Series(y_pred_test_t[0].tolist(), index=l_pred_days, name='Price') 
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=3)
         plt.title(f"RNN on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1])
@@ -325,6 +327,7 @@ def lstm(l_args, s_ticker, s_interval, df_stock):
         df_pred = pd.Series(y_pred_test_t[0].tolist(), index=l_pred_days, name='Price') 
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=3)
         plt.title(f"LSTM on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1])

--- a/prediction_techniques/regression.py
+++ b/prediction_techniques/regression.py
@@ -73,7 +73,8 @@ def regression(l_args, s_ticker, s_interval, df_stock, polynomial):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/regression.py
+++ b/prediction_techniques/regression.py
@@ -60,6 +60,7 @@ def regression(l_args, s_ticker, s_interval, df_stock, polynomial):
         df_pred = pd.Series(l_predictions, index=l_pred_days, name='Price') 
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=2)
         plt.title(f"Regression (polynomial {polynomial}) on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1] )

--- a/prediction_techniques/regression.py
+++ b/prediction_techniques/regression.py
@@ -73,7 +73,7 @@ def regression(l_args, s_ticker, s_interval, df_stock, polynomial):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/sma.py
+++ b/prediction_techniques/sma.py
@@ -57,7 +57,7 @@ def simple_moving_average(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show()
+        plt.show(block=False)
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/sma.py
+++ b/prediction_techniques/sma.py
@@ -57,7 +57,8 @@ def simple_moving_average(l_args, s_ticker, s_interval, df_stock):
         plt.axvspan(df_stock.index[-1], df_pred.index[-1], facecolor='tab:orange', alpha=0.2)
         xmin, xmax, ymin, ymax = plt.axis()
         plt.vlines(df_stock.index[-1], ymin, ymax, linewidth=1, linestyle='--', color='k')
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
         # Print prediction data
         print("Predicted share price:")

--- a/prediction_techniques/sma.py
+++ b/prediction_techniques/sma.py
@@ -42,6 +42,7 @@ def simple_moving_average(l_args, s_ticker, s_interval, df_stock):
         df_pred = pd.Series(l_predictions, index=l_pred_days, name='Price') 
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock['5. adjusted close'], lw=2)
         plt.title(f"{ns_parser.n_length} Moving Average on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1])

--- a/sentiment/google_api.py
+++ b/sentiment/google_api.py
@@ -38,7 +38,8 @@ def mentions(l_args, s_ticker, s_start):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.ylabel('Interest [%]')
         plt.xlabel("Time")
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
         print("")
 
     except:
@@ -71,7 +72,8 @@ def regions(l_args, s_ticker):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.ylabel('Interest [%]')
         plt.xlabel("Time")
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
         print("")
 
     except:

--- a/sentiment/google_api.py
+++ b/sentiment/google_api.py
@@ -38,7 +38,7 @@ def mentions(l_args, s_ticker, s_start):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.ylabel('Interest [%]')
         plt.xlabel("Time")
-        plt.show()
+        plt.show(block=False)
         print("")
 
     except:
@@ -71,7 +71,7 @@ def regions(l_args, s_ticker):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.ylabel('Interest [%]')
         plt.xlabel("Time")
-        plt.show()
+        plt.show(block=False)
         print("")
 
     except:

--- a/sentiment/twitter_api.py
+++ b/sentiment/twitter_api.py
@@ -221,6 +221,7 @@ def sentiment(l_args, s_ticker):
         df_tweets.reset_index(inplace=True)
 
         # Plotting
+        plt.figure()
         plt.subplot(211)
         plt.title(f"Twitter's {s_ticker} sentiment over time is {s_sen} ({n_pct} %)")
         plt.plot(df_tweets.index, df_tweets['sentiment_estimation'].values, lw=3, c='cyan')

--- a/sentiment/twitter_api.py
+++ b/sentiment/twitter_api.py
@@ -273,7 +273,8 @@ def sentiment(l_args, s_ticker):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.ylabel('Sentiment')
         plt.xlabel("Time")
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
 
     except:
         print("")

--- a/sentiment/twitter_api.py
+++ b/sentiment/twitter_api.py
@@ -273,7 +273,7 @@ def sentiment(l_args, s_ticker):
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.ylabel('Sentiment')
         plt.xlabel("Time")
-        plt.show()
+        plt.show(block=False)
 
     except:
         print("")

--- a/technical_analysis/momentum.py
+++ b/technical_analysis/momentum.py
@@ -7,11 +7,11 @@ import matplotlib.pyplot as plt
 
 # ----------------------------------------------------- CCI -----------------------------------------------------
 def cci(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='cci', 
-                                     description=""" The CCI is designed to detect beginning and ending market trends. 
-                                     The range of 100 to -100 is the normal trading range. CCI values outside of this 
-                                     range indicate overbought or oversold conditions. You can also look for price 
-                                     divergence in the CCI. If the price is making new highs, and the CCI is not, 
+    parser = argparse.ArgumentParser(prog='cci',
+                                     description=""" The CCI is designed to detect beginning and ending market trends.
+                                     The range of 100 to -100 is the normal trading range. CCI values outside of this
+                                     range indicate overbought or oversold conditions. You can also look for price
+                                     divergence in the CCI. If the price is making new highs, and the CCI is not,
                                      then a price correction is likely. """)
 
     parser.add_argument('-l', "--length", action="store", dest="n_length", type=check_positive, default=14, help='length')
@@ -25,13 +25,12 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
-            df_ta = ta.cci(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], 
+            df_ta = ta.cci(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'],
                            length=ns_parser.n_length, scalar=ns_parser.n_scalar, offset=ns_parser.n_offset).dropna()
-            
+
+            plt.figure()
             plt.subplot(211)
             plt.title(f"Commodity Channel Index (CCI) on {s_ticker}")
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
@@ -57,11 +56,12 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             plt.ion()
             plt.show()
 
-        # Intraday 
+        # Intraday
         else:
-            df_ta = ta.cci(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], 
+            df_ta = ta.cci(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'],
                            length=ns_parser.n_length, scalar=ns_parser.n_scalar, offset=ns_parser.n_offset).dropna()
-            
+
+            plt.figure()
             plt.subplot(211)
             plt.title(f"Commodity Channel Index (CCI) on {s_ticker}")
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
@@ -90,19 +90,19 @@ def cci(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+
 
 # ----------------------------------------------------- MACD -----------------------------------------------------
 def macd(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='macd', 
-                                     description=""" The Moving Average Convergence Divergence (MACD) is the difference 
-                                     between two Exponential Moving Averages. The Signal line is an Exponential Moving 
-                                     Average of the MACD. \n \n The MACD signals trend changes and indicates the start 
-                                     of new trend direction. High values indicate overbought conditions, low values 
-                                     indicate oversold conditions. Divergence with the price indicates an end to the 
-                                     current trend, especially if the MACD is at extreme high or low values. When the MACD 
-                                     line crosses above the signal line a buy signal is generated. When the MACD crosses 
-                                     below the signal line a sell signal is generated. To confirm the signal, the MACD 
+    parser = argparse.ArgumentParser(prog='macd',
+                                     description=""" The Moving Average Convergence Divergence (MACD) is the difference
+                                     between two Exponential Moving Averages. The Signal line is an Exponential Moving
+                                     Average of the MACD. \n \n The MACD signals trend changes and indicates the start
+                                     of new trend direction. High values indicate overbought conditions, low values
+                                     indicate oversold conditions. Divergence with the price indicates an end to the
+                                     current trend, especially if the MACD is at extreme high or low values. When the MACD
+                                     line crosses above the signal line a buy signal is generated. When the MACD crosses
+                                     below the signal line a sell signal is generated. To confirm the signal, the MACD
                                      should be above zero for a buy, and below zero for a sell. """)
 
     parser.add_argument('-f', "--fast", action="store", dest="n_fast", type=check_positive, default=12,
@@ -121,13 +121,12 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
             df_ta = ta.macd(df_stock['5. adjusted close'], fast=ns_parser.n_fast, slow=ns_parser.n_slow,
                             signal=ns_parser.n_signal, offset=ns_parser.n_offset).dropna()
 
+            plt.figure()
             plt.subplot(211)
             plt.title(f"Moving Average Convergence Divergence (MACD) on {s_ticker}")
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
@@ -140,7 +139,7 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.plot(df_ta.index, df_ta.iloc[:,0].values, 'b', lw=2)
             plt.plot(df_ta.index, df_ta.iloc[:,2].values, 'r', lw=2)
             plt.bar(df_ta.index, df_ta.iloc[:,1].values, color='g')
-            plt.legend([f'MACD Line {df_ta.columns[0]}', 
+            plt.legend([f'MACD Line {df_ta.columns[0]}',
                         f'Signal Line {df_ta.columns[2]}',
                         f'Histogram {df_ta.columns[1]}'])
             plt.xlim(df_stock.index[0], df_stock.index[-1])
@@ -151,11 +150,12 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.ion()
             plt.show()
 
-        # Intraday 
+        # Intraday
         else:
             df_ta = ta.macd(df_stock['4. close'], fast=ns_parser.n_fast, slow=ns_parser.n_slow,
                             signal=ns_parser.n_signal, offset=ns_parser.n_offset).dropna()
 
+            plt.figure()
             plt.subplot(211)
             plt.title(f"Moving Average Convergence Divergence (MACD) on {s_ticker}")
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
@@ -168,7 +168,7 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.plot(df_ta.index, df_ta.iloc[:,0].values, 'b', lw=2)
             plt.plot(df_ta.index, df_ta.iloc[:,2].values, 'r', lw=2)
             plt.bar(df_ta.index, df_ta.iloc[:,1].values, color='g')
-            plt.legend([f'MACD Line {df_ta.columns[0]}', 
+            plt.legend([f'MACD Line {df_ta.columns[0]}',
                         f'Signal Line {df_ta.columns[2]}',
                         f'Histogram {df_ta.columns[1]}'])
             plt.xlim(df_stock.index[0], df_stock.index[-1])
@@ -182,15 +182,15 @@ def macd(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+
 
 # ----------------------------------------------------- RSI -----------------------------------------------------
 def rsi(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='rsi', 
-                                     description=""" The Relative Strength Index (RSI) calculates a ratio of the 
-                                     recent upward price movements to the absolute price movement. The RSI ranges 
-                                     from 0 to 100. The RSI is interpreted as an overbought/oversold indicator when 
-                                     the value is over 70/below 30. You can also look for divergence with price. If 
+    parser = argparse.ArgumentParser(prog='rsi',
+                                     description=""" The Relative Strength Index (RSI) calculates a ratio of the
+                                     recent upward price movements to the absolute price movement. The RSI ranges
+                                     from 0 to 100. The RSI is interpreted as an overbought/oversold indicator when
+                                     the value is over 70/below 30. You can also look for divergence with price. If
                                      the price is making new highs/lows, and the RSI is not, it indicates a reversal. """)
 
     parser.add_argument('-l', "--length", action="store", dest="n_length", type=check_positive, default=14, help='length')
@@ -205,13 +205,12 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
-            df_ta = ta.rsi(df_stock['5. adjusted close'], length=ns_parser.n_length, scalar=ns_parser.n_scalar, 
+            df_ta = ta.rsi(df_stock['5. adjusted close'], length=ns_parser.n_length, scalar=ns_parser.n_scalar,
                            drift=ns_parser.n_drift, offset=ns_parser.n_offset).dropna()
 
+            plt.figure()
             plt.subplot(211)
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
             plt.title(f"Relative Strength Index (RSI) on {s_ticker}")
@@ -238,11 +237,12 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             plt.ion()
             plt.show()
 
-        # Intraday 
+        # Intraday
         else:
-            df_ta = ta.rsi(df_stock['4. close'], length=ns_parser.n_length, scalar=ns_parser.n_scalar, 
+            df_ta = ta.rsi(df_stock['4. close'], length=ns_parser.n_length, scalar=ns_parser.n_scalar,
                            drift=ns_parser.n_drift, offset=ns_parser.n_offset).dropna()
 
+            plt.figure()
             plt.subplot(211)
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
             plt.title(f"Relative Strength Index (RSI) on {s_ticker}")
@@ -267,7 +267,7 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.15, .85], ('OVERSOLD', 'OVERBOUGHT'))
             plt.ion()
-            plt.show()    
+            plt.show()
         print("")
 
     except:
@@ -276,15 +276,15 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
 
 # ----------------------------------------------------- STOCH -----------------------------------------------------
 def stoch(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='stoch', 
-                                     description=""" The Stochastic Oscillator measures where the close is in relation 
-                                     to the recent trading range. The values range from zero to 100. %D values over 75 
-                                     indicate an overbought condition; values under 25 indicate an oversold condition. 
-                                     When the Fast %D crosses above the Slow %D, it is a buy signal; when it crosses 
-                                     below, it is a sell signal. The Raw %K is generally considered too erratic to use 
+    parser = argparse.ArgumentParser(prog='stoch',
+                                     description=""" The Stochastic Oscillator measures where the close is in relation
+                                     to the recent trading range. The values range from zero to 100. %D values over 75
+                                     indicate an overbought condition; values under 25 indicate an oversold condition.
+                                     When the Fast %D crosses above the Slow %D, it is a buy signal; when it crosses
+                                     below, it is a sell signal. The Raw %K is generally considered too erratic to use
                                      for crossover signals. """)
 
-    parser.add_argument('-k', "--fastkperiod", action="store", dest="n_fastkperiod", type=check_positive, default=14, 
+    parser.add_argument('-k', "--fastkperiod", action="store", dest="n_fastkperiod", type=check_positive, default=14,
                         help='The time period of the fastk moving average')
     parser.add_argument('-d', "--slowdperiod", action="store", dest="n_slowdperiod", type=check_positive, default=3,
                         help='TThe time period of the slowd moving average')
@@ -299,13 +299,12 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
-            df_ta = ta.stoch(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], k=ns_parser.n_fastkperiod, 
+            df_ta = ta.stoch(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], k=ns_parser.n_fastkperiod,
                              d=ns_parser.n_slowdperiod, smooth_k=ns_parser.n_slowkperiod, offset=ns_parser.n_offset).dropna()
-            
+
+            plt.figure()
             plt.subplot(211)
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
             plt.title(f"Stochastic Relative Strength Index (STOCH RSI) on {s_ticker}")
@@ -334,11 +333,12 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
             plt.ion()
             plt.show()
 
-        # Intraday 
+        # Intraday
         else:
-            df_ta = ta.stoch(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], k=ns_parser.n_fastkperiod, 
+            df_ta = ta.stoch(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], k=ns_parser.n_fastkperiod,
                              d=ns_parser.n_slowdperiod, smooth_k=ns_parser.n_slowkperiod, offset=ns_parser.n_offset).dropna()
 
+            plt.figure()
             plt.subplot(211)
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
             plt.title(f"Stochastic Relative Strength Index (STOCH RSI) on {s_ticker}")
@@ -370,4 +370,4 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+

--- a/technical_analysis/momentum.py
+++ b/technical_analysis/momentum.py
@@ -52,7 +52,7 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.2, .8], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -81,7 +81,7 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.2, .8], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:
@@ -142,7 +142,7 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.xlabel('Time')
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -169,7 +169,7 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.xlabel('Time')
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:
@@ -225,7 +225,7 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.15, .85], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -255,7 +255,7 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.15, .85], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show()    
+            plt.show(block=False)    
         print("")
 
     except:
@@ -317,7 +317,7 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.1, .9], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -349,7 +349,7 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.1, .9], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:

--- a/technical_analysis/momentum.py
+++ b/technical_analysis/momentum.py
@@ -52,7 +52,8 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.2, .8], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -81,7 +82,8 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.2, .8], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:
@@ -142,7 +144,8 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.xlabel('Time')
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -169,7 +172,8 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.xlabel('Time')
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:
@@ -225,7 +229,8 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.15, .85], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -255,7 +260,8 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.15, .85], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show(block=False)    
+            plt.ion()
+            plt.show()    
         print("")
 
     except:
@@ -317,7 +323,8 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.1, .9], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -349,7 +356,8 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
             plt.gca().twinx()
             plt.ylim(plt.gca().get_ylim())
             plt.yticks([.1, .9], ('OVERSOLD', 'OVERBOUGHT'))
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:

--- a/technical_analysis/momentum.py
+++ b/technical_analysis/momentum.py
@@ -25,6 +25,8 @@ def cci(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
+        plt.figure()
+
         # Daily
         if s_interval == "1440min":
             df_ta = ta.cci(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], 
@@ -119,6 +121,8 @@ def macd(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
+        plt.figure()
+
         # Daily
         if s_interval == "1440min":
             df_ta = ta.macd(df_stock['5. adjusted close'], fast=ns_parser.n_fast, slow=ns_parser.n_slow,
@@ -200,6 +204,8 @@ def rsi(l_args, s_ticker, s_interval, df_stock):
         if l_unknown_args:
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
+
+        plt.figure()
 
         # Daily
         if s_interval == "1440min":
@@ -292,6 +298,8 @@ def stoch(l_args, s_ticker, s_interval, df_stock):
         if l_unknown_args:
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
+
+        plt.figure()
 
         # Daily
         if s_interval == "1440min":

--- a/technical_analysis/overlap.py
+++ b/technical_analysis/overlap.py
@@ -79,7 +79,8 @@ def sma(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -98,7 +99,8 @@ def sma(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:
@@ -139,7 +141,8 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
             print("")
 
         # Intraday 
@@ -161,7 +164,8 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
             print("")
 
     except:

--- a/technical_analysis/overlap.py
+++ b/technical_analysis/overlap.py
@@ -79,7 +79,7 @@ def sma(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -98,7 +98,7 @@ def sma(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:
@@ -139,7 +139,7 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
             print("")
 
         # Intraday 
@@ -161,7 +161,7 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
             print("")
 
     except:

--- a/technical_analysis/trend.py
+++ b/technical_analysis/trend.py
@@ -24,6 +24,8 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
+        plt.figure()
+
         # Daily
         if s_interval == "1440min":
             df_ta = ta.adx(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], length=ns_parser.n_length, 
@@ -118,6 +120,8 @@ def aroon(l_args, s_ticker, s_interval, df_stock):
                          scalar=ns_parser.n_scalar, offset=ns_parser.n_offset).dropna()
         
         plt.subplot(311)
+        plt.figure()
+
         # Daily
         if s_interval == "1440min":
             #plot_stock_and_ta(df_stock['5. adjusted close'], s_ticker, df_ta.iloc[:,-1], "AROON")

--- a/technical_analysis/trend.py
+++ b/technical_analysis/trend.py
@@ -51,7 +51,7 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.ylim([0, 100])
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -80,7 +80,7 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.ylim([0, 100])
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:
@@ -149,7 +149,7 @@ def aroon(l_args, s_ticker, s_interval, df_stock):
         plt.minorticks_on()
         plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
         plt.ylim([-100, 100])
-        plt.show()
+        plt.show(block=False)
         print("")
 
     except:

--- a/technical_analysis/trend.py
+++ b/technical_analysis/trend.py
@@ -6,10 +6,10 @@ register_matplotlib_converters()
 
 # ----------------------------------------------------- ADX -----------------------------------------------------
 def adx(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='adx', 
-                                     description=""" The ADX is a Welles Wilder style moving average of the Directional 
-                                     Movement Index (DX). The values range from 0 to 100, but rarely get above 60. 
-                                     To interpret the ADX, consider a high number to be a strong trend, and a low number, 
+    parser = argparse.ArgumentParser(prog='adx',
+                                     description=""" The ADX is a Welles Wilder style moving average of the Directional
+                                     Movement Index (DX). The values range from 0 to 100, but rarely get above 60.
+                                     To interpret the ADX, consider a high number to be a strong trend, and a low number,
                                      a weak trend. """)
 
     parser.add_argument('-l', "--length", action="store", dest="n_length", type=check_positive, default=14, help='length')
@@ -24,13 +24,12 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
-            df_ta = ta.adx(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], length=ns_parser.n_length, 
+            df_ta = ta.adx(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], length=ns_parser.n_length,
                            scalar=ns_parser.n_scalar, drift=ns_parser.n_drift, offset=ns_parser.n_offset).dropna()
 
+            plt.figure()
             plt.subplot(211)
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
             plt.title(f"Average Directional Movement Index (ADX) on {s_ticker}")
@@ -45,7 +44,7 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.plot(df_ta.index, df_ta.iloc[:,2].values, 'r', lw=1)
             plt.xlim(df_stock.index[0], df_stock.index[-1])
             plt.axhline(25, linewidth=3, color='k', ls='--')
-            plt.legend([f'ADX ({df_ta.columns[0]})', 
+            plt.legend([f'ADX ({df_ta.columns[0]})',
                         f'+DI ({df_ta.columns[1]})',
                         f'- DI ({df_ta.columns[2]})'])
             plt.xlabel('Time')
@@ -56,11 +55,12 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.ion()
             plt.show()
 
-        # Intraday 
+        # Intraday
         else:
-            df_ta = ta.adx(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], length=ns_parser.n_length, 
+            df_ta = ta.adx(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], length=ns_parser.n_length,
                            scalar=ns_parser.n_scalar, drift=ns_parser.n_drift, offset=ns_parser.n_offset).dropna()
-            
+
+            plt.figure()
             plt.subplot(211)
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
             plt.title(f"Average Directional Movement Index (ADX) on {s_ticker}")
@@ -75,7 +75,7 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.plot(df_ta.index, df_ta.iloc[:,2].values, 'r', lw=1)
             plt.xlim(df_stock.index[0], df_stock.index[-1])
             plt.axhline(25, linewidth=3, color='k', ls='--')
-            plt.legend([f'ADX ({df_ta.columns[0]})', 
+            plt.legend([f'ADX ({df_ta.columns[0]})',
                         f'+DI ({df_ta.columns[1]})',
                         f'- DI ({df_ta.columns[2]})'])
             plt.xlabel('Time')
@@ -89,20 +89,20 @@ def adx(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+
 
 # ----------------------------------------------------- AROON -----------------------------------------------------
 def aroon(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='aroon', 
-                                     description=""" The word aroon is Sanskrit for "dawn's early light." The Aroon 
-                                     indicator attempts to show when a new trend is dawning. The indicator consists 
-                                     of two lines (Up and Down) that measure how long it has been since the highest 
-                                     high/lowest low has occurred within an n period range. \n \n When the Aroon Up is 
-                                     staying between 70 and 100 then it indicates an upward trend. When the Aroon Down 
-                                     is staying between 70 and 100 then it indicates an downward trend. A strong upward 
-                                     trend is indicated when the Aroon Up is above 70 while the Aroon Down is below 30. 
-                                     Likewise, a strong downward trend is indicated when the Aroon Down is above 70 while 
-                                     the Aroon Up is below 30. Also look for crossovers. When the Aroon Down crosses above 
+    parser = argparse.ArgumentParser(prog='aroon',
+                                     description=""" The word aroon is Sanskrit for "dawn's early light." The Aroon
+                                     indicator attempts to show when a new trend is dawning. The indicator consists
+                                     of two lines (Up and Down) that measure how long it has been since the highest
+                                     high/lowest low has occurred within an n period range. \n \n When the Aroon Up is
+                                     staying between 70 and 100 then it indicates an upward trend. When the Aroon Down
+                                     is staying between 70 and 100 then it indicates an downward trend. A strong upward
+                                     trend is indicated when the Aroon Up is above 70 while the Aroon Down is below 30.
+                                     Likewise, a strong downward trend is indicated when the Aroon Down is above 70 while
+                                     the Aroon Up is below 30. Also look for crossovers. When the Aroon Down crosses above
                                      the Aroon Up, it indicates a weakening of the upward trend (and vice versa). """)
 
     parser.add_argument('-l', "--length", action="store", dest="n_length", type=check_positive, default=25, help='length')
@@ -118,9 +118,9 @@ def aroon(l_args, s_ticker, s_interval, df_stock):
 
         df_ta = ta.aroon(high=df_stock['2. high'], low=df_stock['3. low'], length=ns_parser.n_length,
                          scalar=ns_parser.n_scalar, offset=ns_parser.n_offset).dropna()
-        
-        plt.subplot(311)
+
         plt.figure()
+        plt.subplot(311)
 
         # Daily
         if s_interval == "1440min":
@@ -141,7 +141,7 @@ def aroon(l_args, s_ticker, s_interval, df_stock):
         plt.plot(df_ta.index, df_ta.iloc[:,1].values, 'g', lw=2)
         plt.xlim(df_stock.index[0], df_stock.index[-1])
         plt.axhline(50, linewidth=1, color='k', ls='--')
-        plt.legend([f'Aroon DOWN ({df_ta.columns[0]})', 
+        plt.legend([f'Aroon DOWN ({df_ta.columns[0]})',
                     f'Aroon UP ({df_ta.columns[1]})'])
         plt.grid(b=True, which='major', color='#666666', linestyle='-')
         plt.minorticks_on()
@@ -161,4 +161,4 @@ def aroon(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+

--- a/technical_analysis/trend.py
+++ b/technical_analysis/trend.py
@@ -51,7 +51,8 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.ylim([0, 100])
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -80,7 +81,8 @@ def adx(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.ylim([0, 100])
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:
@@ -149,7 +151,8 @@ def aroon(l_args, s_ticker, s_interval, df_stock):
         plt.minorticks_on()
         plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
         plt.ylim([-100, 100])
-        plt.show(block=False)
+        plt.ion()
+        plt.show()
         print("")
 
     except:

--- a/technical_analysis/volatility.py
+++ b/technical_analysis/volatility.py
@@ -49,7 +49,8 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
             
         # Intraday 
         else:
@@ -70,7 +71,8 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:

--- a/technical_analysis/volatility.py
+++ b/technical_analysis/volatility.py
@@ -6,16 +6,16 @@ register_matplotlib_converters()
 
 # ----------------------------------------------------- BBANDS -----------------------------------------------------
 def bbands(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='bbands', 
-                                     description=""" Bollinger Bands consist of three lines. The middle band is a simple 
-                                     moving average (generally 20 periods) of the typical price (TP). The upper and lower 
-                                     bands are F standard deviations (generally 2) above and below the middle band. 
+    parser = argparse.ArgumentParser(prog='bbands',
+                                     description=""" Bollinger Bands consist of three lines. The middle band is a simple
+                                     moving average (generally 20 periods) of the typical price (TP). The upper and lower
+                                     bands are F standard deviations (generally 2) above and below the middle band.
                                      The bands widen and narrow when the volatility of the price is higher or lower, respectively.
-                                     \n \nBollinger Bands do not, in themselves, generate buy or sell signals; they are an 
-                                     indicator of overbought or oversold conditions. When the price is near the upper or lower 
-                                     band it indicates that a reversal may be imminent. The middle band becomes a support or 
-                                     resistance level. The upper and lower bands can also be interpreted as price targets. 
-                                     When the price bounces off of the lower band and crosses the middle band, then the 
+                                     \n \nBollinger Bands do not, in themselves, generate buy or sell signals; they are an
+                                     indicator of overbought or oversold conditions. When the price is near the upper or lower
+                                     band it indicates that a reversal may be imminent. The middle band becomes a support or
+                                     resistance level. The upper and lower bands can also be interpreted as price targets.
+                                     When the price bounces off of the lower band and crosses the middle band, then the
                                      upper band becomes the price target. """)
 
     parser.add_argument('-l', "--length", action="store", dest="n_length", type=check_positive, default=5, help='length')
@@ -30,9 +30,12 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
+        # create new figure
+        plt.figure()
+
         # Daily
         if s_interval == "1440min":
-            df_ta = ta.bbands(close=df_stock['5. adjusted close'], length=ns_parser.n_length, std=ns_parser.n_std, 
+            df_ta = ta.bbands(close=df_stock['5. adjusted close'], length=ns_parser.n_length, std=ns_parser.n_std,
                               mamode=ns_parser.s_mamode, offset=ns_parser.n_offset).dropna()
             #plot_stock_ta(df_stock['5. adjusted close'], s_ticker, df_ta, "BBANDS")
 
@@ -51,10 +54,10 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.ion()
             plt.show()
-            
-        # Intraday 
+
+        # Intraday
         else:
-            df_ta = ta.bbands(close=df_stock['4. close'], length=ns_parser.n_length, std=ns_parser.n_std, 
+            df_ta = ta.bbands(close=df_stock['4. close'], length=ns_parser.n_length, std=ns_parser.n_std,
                               mamode=ns_parser.s_mamode, offset=ns_parser.n_offset).dropna()
             #plot_stock_ta(df_stock['4. close'], s_ticker, df_ta, "BBANDS")
 
@@ -77,4 +80,4 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+

--- a/technical_analysis/volatility.py
+++ b/technical_analysis/volatility.py
@@ -30,15 +30,13 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        # create new figure
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
             df_ta = ta.bbands(close=df_stock['5. adjusted close'], length=ns_parser.n_length, std=ns_parser.n_std,
                               mamode=ns_parser.s_mamode, offset=ns_parser.n_offset).dropna()
             #plot_stock_ta(df_stock['5. adjusted close'], s_ticker, df_ta, "BBANDS")
 
+            plt.figure()
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, color='k', lw=3)
             plt.plot(df_ta.index, df_ta.iloc[:,0].values, 'r', lw=2)
             plt.plot(df_ta.index, df_ta.iloc[:,1].values, 'b', lw=1.5, ls='--')
@@ -61,6 +59,7 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
                               mamode=ns_parser.s_mamode, offset=ns_parser.n_offset).dropna()
             #plot_stock_ta(df_stock['4. close'], s_ticker, df_ta, "BBANDS")
 
+            plt.figure()
             plt.plot(df_stock.index, df_stock['4. close'].values, color='k', lw=3)
             plt.plot(df_ta.index, df_ta.iloc[:,0].values, 'r', lw=2)
             plt.plot(df_ta.index, df_ta.iloc[:,1].values, 'b', lw=1.5, ls='--')

--- a/technical_analysis/volatility.py
+++ b/technical_analysis/volatility.py
@@ -49,7 +49,7 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
             
         # Intraday 
         else:
@@ -70,7 +70,7 @@ def bbands(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:

--- a/technical_analysis/volume.py
+++ b/technical_analysis/volume.py
@@ -6,16 +6,16 @@ register_matplotlib_converters()
 
 # ------------------------------------------------------- AD -------------------------------------------------------
 def ad(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='ad', 
-                                     description=""" The Accumulation/Distribution Line is similar to the On Balance 
-                                     Volume (OBV), which sums the volume times +1/-1 based on whether the close is 
-                                     higher than the previous close. The Accumulation/Distribution indicator, however 
-                                     multiplies the volume by the close location value (CLV). The CLV is based on the 
-                                     movement of the issue within a single bar and can be +1, -1 or zero. \n \n 
-                                     The Accumulation/Distribution Line is interpreted by looking for a divergence in 
-                                     the direction of the indicator relative to price. If the Accumulation/Distribution 
-                                     Line is trending upward it indicates that the price may follow. Also, if the 
-                                     Accumulation/Distribution Line becomes flat while the price is still rising (or falling) 
+    parser = argparse.ArgumentParser(prog='ad',
+                                     description=""" The Accumulation/Distribution Line is similar to the On Balance
+                                     Volume (OBV), which sums the volume times +1/-1 based on whether the close is
+                                     higher than the previous close. The Accumulation/Distribution indicator, however
+                                     multiplies the volume by the close location value (CLV). The CLV is based on the
+                                     movement of the issue within a single bar and can be +1, -1 or zero. \n \n
+                                     The Accumulation/Distribution Line is interpreted by looking for a divergence in
+                                     the direction of the indicator relative to price. If the Accumulation/Distribution
+                                     Line is trending upward it indicates that the price may follow. Also, if the
+                                     Accumulation/Distribution Line becomes flat while the price is still rising (or falling)
                                      then it signals an impending flattening of the price.""")
 
     parser.add_argument('-o', "--offset", action="store", dest="n_offset", type=check_positive, default=0, help='offset')
@@ -28,20 +28,20 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
 
         # Daily
         if s_interval == "1440min":
             # Use open stock values
             if ns_parser.b_use_open:
-                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], 
+                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'],
                               volume=df_stock['6. volume'], offset=ns_parser.n_offset, open_=df_stock['1. open']).dropna()
             # Do not use open stock values
             else:
-                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'], 
+                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['5. adjusted close'],
                               volume=df_stock['6. volume'], offset=ns_parser.n_offset).dropna()
 
             axPrice = plt.subplot(211)
+            plt.figure()
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
             plt.title(f"Accumulation/Distribution Line (AD) on {s_ticker}")
             plt.xlim(df_stock.index[0], df_stock.index[-1])
@@ -63,18 +63,19 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.ion()
             plt.show()
 
-        # Intraday 
+        # Intraday
         else:
             # Use open stock values
             if ns_parser.b_use_open:
-                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], 
+                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'],
                               volume=df_stock['5. volume'], offset=ns_parser.n_offset, open_=df_stock['1. open']).dropna()
             # Do not use open stock values
             else:
-                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'], 
+                df_ta = ta.ad(high=df_stock['2. high'], low=df_stock['3. low'], close=df_stock['4. close'],
                               volume=df_stock['5. volume'], offset=ns_parser.n_offset).dropna()
-            
+
             axPrice = plt.subplot(211)
+            plt.figure()
             plt.plot(df_stock.index, df_stock['4. close'].values, 'k', lw=2)
             plt.title(f"Accumulation/Distribution Line (AD) on {s_ticker}")
             plt.xlim(df_stock.index[0], df_stock.index[-1])
@@ -100,17 +101,17 @@ def ad(l_args, s_ticker, s_interval, df_stock):
     except:
         print("")
         return
-    
+
 
 # ------------------------------------------------------- OBV -------------------------------------------------------
 def obv(l_args, s_ticker, s_interval, df_stock):
-    parser = argparse.ArgumentParser(prog='obv', 
-                                     description=""" The On Balance Volume (OBV) is a cumulative total of the up and 
-                                     down volume. When the close is higher than the previous close, the volume is added 
-                                     to the running total, and when the close is lower than the previous close, the volume 
-                                     is subtracted from the running total. \n \n To interpret the OBV, look for the OBV 
-                                     to move with the price or precede price moves. If the price moves before the OBV, 
-                                     then it is a non-confirmed move. A series of rising peaks, or falling troughs, in the 
+    parser = argparse.ArgumentParser(prog='obv',
+                                     description=""" The On Balance Volume (OBV) is a cumulative total of the up and
+                                     down volume. When the close is higher than the previous close, the volume is added
+                                     to the running total, and when the close is lower than the previous close, the volume
+                                     is subtracted from the running total. \n \n To interpret the OBV, look for the OBV
+                                     to move with the price or precede price moves. If the price moves before the OBV,
+                                     then it is a non-confirmed move. A series of rising peaks, or falling troughs, in the
                                      OBV indicates a strong trend. If the OBV is flat, then the market is not trending. """)
 
     parser.add_argument('-o', "--offset", action="store", dest="n_offset", type=check_positive, default=0, help='offset')
@@ -122,13 +123,12 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
-        plt.figure()
-
         # Daily
         if s_interval == "1440min":
             df_ta = ta.obv(close=df_stock['5. adjusted close'], volume=df_stock['6. volume'], offset=ns_parser.n_offset).dropna()
 
             axPrice = plt.subplot(211)
+            plt.figure()
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
             plt.title(f"On-Balance Volume (OBV) on {s_ticker}")
             plt.xlim(df_stock.index[0], df_stock.index[-1])
@@ -148,13 +148,14 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
             plt.ion()
             plt.show()
-           
 
-        # Intraday 
+
+        # Intraday
         else:
             df_ta = ta.obv(close=df_stock['4. close'], volume=df_stock['5. volume'], offset=ns_parser.n_offset).dropna()
 
             axPrice = plt.subplot(211)
+            plt.figure()
             plt.plot(df_stock.index, df_stock['5. adjusted close'].values, 'k', lw=2)
             plt.title(f"On-Balance Volume (OBV) on {s_ticker}")
             plt.xlim(df_stock.index[0], df_stock.index[-1])
@@ -179,4 +180,4 @@ def obv(l_args, s_ticker, s_interval, df_stock):
 
     except:
         print("")
-    
+

--- a/technical_analysis/volume.py
+++ b/technical_analysis/volume.py
@@ -28,6 +28,8 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
 
+        plt.figure()
+
         # Daily
         if s_interval == "1440min":
             # Use open stock values
@@ -119,6 +121,8 @@ def obv(l_args, s_ticker, s_interval, df_stock):
         if l_unknown_args:
             print(f"The following args couldn't be interpreted: {l_unknown_args}\n")
             return
+
+        plt.figure()
 
         # Daily
         if s_interval == "1440min":

--- a/technical_analysis/volume.py
+++ b/technical_analysis/volume.py
@@ -58,7 +58,8 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         # Intraday 
         else:
@@ -90,7 +91,8 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
         print("")
 
     except:
@@ -140,7 +142,8 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
            
 
         # Intraday 
@@ -165,7 +168,8 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show(block=False)
+            plt.ion()
+            plt.show()
 
         print("")
 

--- a/technical_analysis/volume.py
+++ b/technical_analysis/volume.py
@@ -58,7 +58,7 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
 
         # Intraday 
         else:
@@ -90,7 +90,7 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
         print("")
 
     except:
@@ -140,7 +140,7 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
            
 
         # Intraday 
@@ -165,7 +165,7 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which='major', color='#666666', linestyle='-')
             plt.minorticks_on()
             plt.grid(b=True, which='minor', color='#999999', linestyle='-', alpha=0.2)
-            plt.show()
+            plt.show(block=False)
 
         print("")
 


### PR DESCRIPTION
- Adds block=False to all instances where show is called on plot objects

It seems like it limits the utility of the terminal a lot to have it just hang there while plots are showing, especially when you want to have more than one plot on screen at once. Pyplot supports a block=False option that just returns back to the main loop after kicking off the plotter. I went ahead and added that param to all the uses of show(). If it would be better, I could gate the nonblocking behavior behind a config option? but I can't really think of a situation in which you'd want the blocking behavior. Feel free to correct me if I'm wrong however.