### PR TITLE
replace fuzzywuzzy with rapidfuzz

### DIFF
--- a/due_diligence/business_insider_api.py
+++ b/due_diligence/business_insider_api.py
@@ -8,7 +8,7 @@ import json
 import config_terminal as cfg
 from datetime import datetime
 import argparse
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import matplotlib.pyplot as plt
 from pandas.plotting import register_matplotlib_converters
 register_matplotlib_converters()

--- a/fundamental_analysis/business_insider_api.py
+++ b/fundamental_analysis/business_insider_api.py
@@ -6,7 +6,7 @@ import json
 import config_terminal as cfg
 from datetime import datetime
 import argparse
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 # ---------------------------------------------------- MANAGEMENT ----------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ flatbuffers==1.12
 ftfy==5.9
 FundamentalAnalysis==0.2.6
 future==0.18.2
-fuzzywuzzy==0.18.0
 gast==0.3.3
 gdown==3.12.2
 gensim==3.8.3
@@ -78,10 +77,10 @@ PyMeeus==0.4.2
 pyparsing==2.4.7
 PySocks==1.7.1
 python-dateutil==2.8.1
-python-Levenshtein==0.12.2
 pytrends==4.7.3
 pytz==2019.3
 Quandl==3.6.0
+rapidfuzz==1.1.1
 regex==2020.11.13
 requests==2.25.1
 requests-oauthlib==1.3.0


### PR DESCRIPTION
This PR replaces FuzzyWuzzy with RapidFuzz, which is faster and uses a MIT license.
Following https://news.ycombinator.com/item?id=26259362 the current library might cause license issues, while a MIT licensed one definitely does not.
Another advantage is that it comes with wheels, so the user does not need a C/C++ compiler.