### PR TITLE
GitHub Actions: Add more flake8 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: bandit -r . || true
       - run: black --check .
       - run: codespell --ignore-words-list="mape" --quiet-level=2  # --skip=""
-      - run: flake8 . --count --show-source --statistics
+      - run: flake8 . --count --ignore=E203,E302,E722,E741,F401,F841,W503 --max-line-length=140 --show-source --statistics
       - run: mypy --ignore-missing-imports . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: bandit -r . || true
       - run: black --check .
       - run: codespell --ignore-words-list="mape" --quiet-level=2  # --skip=""
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --show-source --statistics
       - run: mypy --ignore-missing-imports . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check


### PR DESCRIPTION
Instead of `selecting` a small list of key tests, let's `ignore` only those tests that our codebase currently fails.

Future PRs can clean up failing tests and remove them from the list.  High priority items to remove would be:
```
1     E722 do not use bare 'except'
1     E741 ambiguous variable name 'l'
20    F401 '.discovery' imported but unused
5     F841 local variable 'line' is assigned to but never used
```