### PR TITLE
Do not use the ambiguous variable name 'l'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: bandit -r . || true
       - run: black --check .
       - run: codespell --ignore-words-list="mape" --quiet-level=2  # --skip=""
-      - run: flake8 . --count --ignore=E203,E302,E722,E741,F401,F841,W503 --max-line-length=140 --show-source --statistics
+      - run: flake8 . --count --ignore=E203,E302,E722,F401,F841,W503 --max-line-length=140 --show-source --statistics
       - run: mypy --ignore-missing-imports . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -206,10 +206,10 @@ def int_or_round_float(x):
 
 
 # -----------------------------------------------------------------------------------------------------------------------
-def divide_chunks(l, n):
-    # looping till length l
-    for i in range(0, len(l), n):
-        yield l[i : i + n]
+def divide_chunks(data, n):
+    # looping till length of data
+    for i in range(0, len(data), n):
+        yield data[i : i + n]
 
 
 # -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`l` and `1` look too much alike to a casual reader so `l` should not be used as a variable name.