### PR TITLE
Fix local variable is assigned to but never used

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: bandit -r . || true
       - run: black --check .
       - run: codespell --ignore-words-list="mape" --quiet-level=2 --skip=".git" # --skip=""
-      - run: flake8 . --count --ignore=E203,E302,F401,F841,W503 --max-line-length=140 --show-source --statistics
+      - run: flake8 . --count --ignore=E203,E302,F401,W503 --max-line-length=140 --show-source --statistics
       - run: mypy --ignore-missing-imports . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/gamestonk_terminal/sentiment/twitter_api.py
+++ b/gamestonk_terminal/sentiment/twitter_api.py
@@ -166,7 +166,7 @@ def inference(l_args, s_ticker):
             n_pct = round(100 * n_pos / df_tweets["probability"].sum())
         else:
             n_neg = abs(df_tweets[df_tweets["prob_sen"] < 0]["prob_sen"].sum())
-            n_pct = round(100 * n_neg / df_tweets["probability"].sum())
+            n_pct = round(100 * n_neg / df_tweets["probability"].sum())  # noqa: F841
 
         # Parse tweets
         dt_from = dateutil.parser.parse(df_tweets["created_at"].values[-1])

--- a/gamestonk_terminal/sentiment/twitter_api.py
+++ b/gamestonk_terminal/sentiment/twitter_api.py
@@ -163,10 +163,10 @@ def inference(l_args, s_ticker):
         if df_tweets["sentiment_estimation"].values[-1] > 0:
             n_pos = df_tweets[df_tweets["prob_sen"] > 0]["prob_sen"].sum()
             # pylint: disable=unused-variable
-            n_pct = round(100 * n_pos / df_tweets["probability"].sum())  # noqa: F841
+            n_pct = round(100 * n_pos / df_tweets["probability"].sum())
         else:
             n_neg = abs(df_tweets[df_tweets["prob_sen"] < 0]["prob_sen"].sum())
-            n_pct = round(100 * n_neg / df_tweets["probability"].sum())  # noqa: F841
+            n_pct = round(100 * n_neg / df_tweets["probability"].sum())
 
         # Parse tweets
         dt_from = dateutil.parser.parse(df_tweets["created_at"].values[-1])

--- a/gamestonk_terminal/sentiment/twitter_api.py
+++ b/gamestonk_terminal/sentiment/twitter_api.py
@@ -163,10 +163,10 @@ def inference(l_args, s_ticker):
         if df_tweets["sentiment_estimation"].values[-1] > 0:
             n_pos = df_tweets[df_tweets["prob_sen"] > 0]["prob_sen"].sum()
             # pylint: disable=unused-variable
-            n_pct = round(100 * n_pos / df_tweets["probability"].sum())
+            n_pct = round(100 * n_pos / df_tweets["probability"].sum())  # noqa: F841
         else:
             n_neg = abs(df_tweets[df_tweets["prob_sen"] < 0]["prob_sen"].sum())
-            n_pct = round(100 * n_neg / df_tweets["probability"].sum())
+            n_pct = round(100 * n_neg / df_tweets["probability"].sum())  # noqa: F841
 
         # Parse tweets
         dt_from = dateutil.parser.parse(df_tweets["created_at"].values[-1])

--- a/gamestonk_terminal/technical_analysis/overlap.py
+++ b/gamestonk_terminal/technical_analysis/overlap.py
@@ -215,7 +215,7 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.ylabel("Share Price ($)")
             plt.legend([s_ticker, "VWAP"])
             # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()
+            axVolume = axPrice.twinx()  # noqa: F841
             plt.bar(
                 df_stock.index,
                 df_stock["6. volume"].values,
@@ -248,7 +248,8 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.xlabel("Time")
             plt.ylabel("Share Price ($)")
             plt.legend([s_ticker, "VWAP"])
-            axVolume = axPrice.twinx()
+            # pylint: disable=unused-variable
+            axVolume = axPrice.twinx()  # noqa: F841
             plt.bar(
                 df_stock.index,
                 df_stock["5. volume"].values,

--- a/gamestonk_terminal/technical_analysis/overlap.py
+++ b/gamestonk_terminal/technical_analysis/overlap.py
@@ -214,8 +214,7 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.xlabel("Time")
             plt.ylabel("Share Price ($)")
             plt.legend([s_ticker, "VWAP"])
-            # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()  # noqa: F841
+            _ = axPrice.twinx()
             plt.bar(
                 df_stock.index,
                 df_stock["6. volume"].values,
@@ -248,8 +247,7 @@ def vwap(l_args, s_ticker, s_interval, df_stock):
             plt.xlabel("Time")
             plt.ylabel("Share Price ($)")
             plt.legend([s_ticker, "VWAP"])
-            # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()  # noqa: F841
+            _ = axPrice.twinx()
             plt.bar(
                 df_stock.index,
                 df_stock["5. volume"].values,

--- a/gamestonk_terminal/technical_analysis/volume.py
+++ b/gamestonk_terminal/technical_analysis/volume.py
@@ -78,8 +78,7 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-            # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()  # noqa: F841
+            _ = axPrice.twinx()
             plt.bar(
                 df_stock.index,
                 df_stock["6. volume"].values,
@@ -128,8 +127,7 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-            # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()  # noqa: F841
+            _ = axPrice.twinx()
             plt.bar(
                 df_stock.index,
                 df_stock["5. volume"].values,
@@ -203,8 +201,7 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-            # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()  # noqa: F841
+            _ = axPrice.twinx()
             plt.bar(
                 df_stock.index,
                 df_stock["6. volume"].values,
@@ -238,8 +235,7 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-            # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()  # noqa: F841
+            _ = axPrice.twinx()
             plt.bar(
                 df_stock.index,
                 df_stock["5. volume"].values,

--- a/gamestonk_terminal/technical_analysis/volume.py
+++ b/gamestonk_terminal/technical_analysis/volume.py
@@ -79,7 +79,7 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
             # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()
+            axVolume = axPrice.twinx()  # noqa: F841
             plt.bar(
                 df_stock.index,
                 df_stock["6. volume"].values,
@@ -128,7 +128,8 @@ def ad(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-            axVolume = axPrice.twinx()
+            # pylint: disable=unused-variable
+            axVolume = axPrice.twinx()  # noqa: F841
             plt.bar(
                 df_stock.index,
                 df_stock["5. volume"].values,
@@ -203,7 +204,7 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
             # pylint: disable=unused-variable
-            axVolume = axPrice.twinx()
+            axVolume = axPrice.twinx()  # noqa: F841
             plt.bar(
                 df_stock.index,
                 df_stock["6. volume"].values,
@@ -237,7 +238,8 @@ def obv(l_args, s_ticker, s_interval, df_stock):
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
             plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-            axVolume = axPrice.twinx()
+            # pylint: disable=unused-variable
+            axVolume = axPrice.twinx()  # noqa: F841
             plt.bar(
                 df_stock.index,
                 df_stock["5. volume"].values,


### PR DESCRIPTION
% `flake8 --select=F841 --statistics`
```
./gamestonk_terminal/technical_analysis/volume.py:132:13: F841 local variable 'axVolume' is assigned to but never used
./gamestonk_terminal/technical_analysis/volume.py:241:13: F841 local variable 'axVolume' is assigned to but never used
./gamestonk_terminal/technical_analysis/overlap.py:251:13: F841 local variable 'axVolume' is assigned to but never used
./gamestonk_terminal/sentiment/twitter_api.py:169:13: F841 local variable 'n_pct' is assigned to but never used
```
We are assigning values to `n_pct` and `axVolume` but we are never using the results.  __Could these lines of code be safely eliminated?__

If there are desirable side effects from calling `axPrice.twinx()` then both flake8 and pylint should be satisfied with
`_ = axPrice.twinx()` instead of assigning to _named_ variable `axVolume`.