### PR TITLE
Adds export command to save LOADed data to a variety of formats: the sequel

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+from sys import stdout
 import pandas as pd
 from alpha_vantage.timeseries import TimeSeries
 
@@ -225,6 +226,37 @@ def view(l_args, s_ticker, s_start, s_interval, df_stock):
     plot_view_stock(df_stock.iloc[:, ln_col_idx], ns_parser.s_ticker)
 
 
+# ----------------------------------------------------- EXPORT -----------------------------------------------------
+def export(l_args, df_stock):
+    parser = argparse.ArgumentParser(prog='export', description='Exports the current dataframe to a file or stdout')
+    parser.add_argument('-f', "--filename", type=str, dest="s_filename", default=stdout, help="Where to save the export (stdout if unspecified)")
+    parser.add_argument('-F', "--format", dest="s_format", type=str, default="csv", help="Export historical data into following formats: csv, json, excel, clipboard")
+
+    try:
+        (ns_parser, l_unknown_args) = parser.parse_known_args(l_args)
+        s_format = ns_parser.s_format
+        s_filename = ns_parser.s_filename
+    except SystemExit:
+        print("")
+        return
+
+    if l_unknown_args:
+        print(f"The following args couldn't be interpreted: {l_unknown_args}")
+
+    if df_stock.empty:
+        print("No data loaded yet to export.")
+        return
+
+    if s_format == "csv":
+        df_stock.to_csv(s_filename)
+    elif s_format == "json":
+        df_stock.to_json(s_filename)
+    elif s_format == "excel":
+        df_stock.to_excel(s_filename)
+    elif s_format == "clipboard":
+        df_stock.to_clipboard()
+
+
 # ----------------------------------------------------- HELP ------------------------------------------------------------
 def print_help(s_ticker, s_start, s_interval, b_is_market_open):
     """Print help"""
@@ -235,6 +267,8 @@ def print_help(s_ticker, s_start, s_interval, b_is_market_open):
     print("   clear       clear a specific stock ticker from analysis")
     print("   load        load a specific stock ticker for analysis")
     print("   view        view and load a specific stock ticker for technical analysis")
+    if s_ticker:
+        print("   export      export the currently loaded dataframe to a file or stdout")
 
     s_intraday = (f"Intraday {s_interval}", "Daily")[s_interval == "1440min"]
     if s_ticker and s_start:
@@ -303,6 +337,7 @@ def main():
             "clear",
             "load",
             "view",
+            "export",
             "disc",
             "mill",
             "sen",
@@ -359,6 +394,9 @@ def main():
 
         elif ns_known_args.opt == "view":
             view(l_args, s_ticker, s_start, s_interval, df_stock)
+
+        elif ns_known_args.opt == "export":
+            export(l_args, df_stock)
 
         elif ns_known_args.opt == "disc":
             b_quit = dm.disc_menu()

--- a/terminal.py
+++ b/terminal.py
@@ -228,9 +228,25 @@ def view(l_args, s_ticker, s_start, s_interval, df_stock):
 
 # ----------------------------------------------------- EXPORT -----------------------------------------------------
 def export(l_args, df_stock):
-    parser = argparse.ArgumentParser(prog='export', description='Exports the current dataframe to a file or stdout')
-    parser.add_argument('-f', "--filename", type=str, dest="s_filename", default=stdout, help="Where to save the export (stdout if unspecified)")
-    parser.add_argument('-F', "--format", dest="s_format", type=str, default="csv", help="Export historical data into following formats: csv, json, excel, clipboard")
+    parser = argparse.ArgumentParser(
+        prog="export", description="Exports the current dataframe to a file or stdout"
+    )
+    parser.add_argument(
+        "-f",
+        "--filename",
+        type=str,
+        dest="s_filename",
+        default=stdout,
+        help="Where to save the export (stdout if unspecified)",
+    )
+    parser.add_argument(
+        "-F",
+        "--format",
+        dest="s_format",
+        type=str,
+        default="csv",
+        help="Export historical data into following formats: csv, json, excel, clipboard",
+    )
 
     try:
         (ns_parser, l_unknown_args) = parser.parse_known_args(l_args)
@@ -268,7 +284,9 @@ def print_help(s_ticker, s_start, s_interval, b_is_market_open):
     print("   load        load a specific stock ticker for analysis")
     print("   view        view and load a specific stock ticker for technical analysis")
     if s_ticker:
-        print("   export      export the currently loaded dataframe to a file or stdout")
+        print(
+            "   export      export the currently loaded dataframe to a file or stdout"
+        )
 
     s_intraday = (f"Intraday {s_interval}", "Daily")[s_interval == "1440min"]
     if s_ticker and s_start:


### PR DESCRIPTION
Recreated this on a new branch since there had been so many changes in the meantime. From the original PR:

This pull implements extremely basic export functionality and is intended to contribute toward a resolution of #7.

I'm just exposing the built in pandas IO formats on df_stock, nothing fancy. The only things the user can specify are the file format (I went ahead and implemented the ones I thought would be most desired but it would be easy to expose others) and the destination filename (the export goes to stdout if -f is unspecified). Can throw an exception in case you specify a format (e.g. excel) that doesn't support output to stdout, but don't also specify the filename. Otherwise works well and does what it says on the tin.