### PR TITLE
Get main data from yahoo finance

### DIFF
--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -301,3 +301,10 @@ def lett_to_num(word: str) -> str:
     for (a, b) in replacements:
         word = word.replace(a, b)
     return word
+
+
+def check_sources(source: str) -> str:
+    available_historical_price_sources = ["quandl", "av"]
+    if source in available_historical_price_sources:
+        return source
+    raise argparse.ArgumentTypeError("This source for historical data is not available.")

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -304,7 +304,7 @@ def lett_to_num(word: str) -> str:
 
 
 def check_sources(source: str) -> str:
-    available_historical_price_sources = ["quandl", "av"]
+    available_historical_price_sources = ["yf", "av"]
     if source in available_historical_price_sources:
         return source
     raise argparse.ArgumentTypeError(

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -307,4 +307,6 @@ def check_sources(source: str) -> str:
     available_historical_price_sources = ["quandl", "av"]
     if source in available_historical_price_sources:
         return source
-    raise argparse.ArgumentTypeError("This source for historical data is not available.")
+    raise argparse.ArgumentTypeError(
+        "This source for historical data is not available."
+    )

--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -111,15 +111,14 @@ def load(l_args, s_ticker, s_start, s_interval, df_stock):
         choices=[1, 5, 15, 30, 60],
         help="Intraday stock minutes",
     )
-
     parser.add_argument(
         "--source",
         action="store",
         dest="source",
         type=check_sources,
-        default="quandl",
+        default="yf",
         help="Source of historical data. Intraday: Only 'av' available."
-        "Daily: 'quandl' and 'av' available.",
+        "Daily: 'yf' and 'av' available.",
     )
 
     try:
@@ -154,7 +153,7 @@ def load(l_args, s_ticker, s_start, s_interval, df_stock):
                 # Slice dataframe from the starting date YYYY-MM-DD selected
                 df_stock = df_stock[ns_parser.s_start_date :]
 
-            elif ns_parser.source == "quandl":
+            elif ns_parser.source == "yf":
                 df_stock = yf.download(
                     ns_parser.s_ticker, start=ns_parser.s_start_date, progress=False
                 )
@@ -186,14 +185,14 @@ def load(l_args, s_ticker, s_start, s_interval, df_stock):
                 # Slice dataframe from the starting date YYYY-MM-DD selected
                 df_stock = df_stock[ns_parser.s_start_date :]
 
-            elif ns_parser.source == "quandl":
+            elif ns_parser.source == "yf":
                 print(
-                    "Unfortunately, quandl historical data doesn't contain intraday prices"
+                    "Unfortunately, yahoo finance historical data doesn't contain intraday prices"
                 )
 
     except Exception as e:
         print(e)
-        print("Either the ticker or the API_KEY are invalids. Try again!")
+        print("Either the ticker or the API_KEY are invalids. Try again!\n")
         return [s_ticker, s_start, s_interval, df_stock]
 
     s_intraday = (f"Intraday {s_interval}", "Daily")[s_interval == "1440min"]

--- a/gamestonk_terminal/res_menu.py
+++ b/gamestonk_terminal/res_menu.py
@@ -2,9 +2,15 @@ import argparse
 import webbrowser
 
 
-# -----------------------------------------------------------------------------------------------------------------------
-def print_research():
+def print_research(s_ticker, s_start, s_interval):
     """ Print help """
+
+    s_intraday = (f"Intraday {s_interval}", "Daily")[s_interval == "1440min"]
+
+    if s_start:
+        print(f"\n{s_intraday} Stock: {s_ticker} (from {s_start.strftime('%Y-%m-%d')})")
+    else:
+        print(f"\n{s_intraday} Stock: {s_ticker}")
 
     print("\nResearch Mode:")
     print("   help              show this fundamental analysis menu again")
@@ -33,8 +39,7 @@ def print_research():
     print("")
 
 
-# ---------------------------------------------------- MENU ----------------------------------------------------
-def res_menu(s_ticker):
+def res_menu(s_ticker, s_start, s_interval):
     # Add list of arguments that the research parser accepts
     res_parser = argparse.ArgumentParser(prog="discovery", add_help=False)
     res_parser.add_argument(
@@ -64,7 +69,7 @@ def res_menu(s_ticker):
         ],
     )
 
-    print_research()
+    print_research(s_ticker, s_start, s_interval)
 
     # Loop forever and ever
     while True:
@@ -80,7 +85,7 @@ def res_menu(s_ticker):
 
         try:
             if ns_known_args.cmd == "help":
-                print_research()
+                print_research(s_ticker, s_start, s_interval)
 
             elif ns_known_args.cmd == "q":
                 # Just leave the RES menu
@@ -90,115 +95,79 @@ def res_menu(s_ticker):
                 # Abandon the program
                 return True
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "macroaxis":
                 webbrowser.open(f"https://www.macroaxis.com/invest/market/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "yahoo":
                 webbrowser.open(f"https://finance.yahoo.com/quote/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "finviz":
                 webbrowser.open(f"https://finviz.com/quote.ashx?t={s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "marketwatch":
                 webbrowser.open(
                     f"https://www.marketwatch.com/investing/stock/{s_ticker}"
                 )
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "fool":
                 webbrowser.open(f"https://www.fool.com/quote/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "businessinsider":
                 webbrowser.open(
                     f"https://markets.businessinsider.com/stocks/{s_ticker}-stock/"
                 )
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "fmp":
                 webbrowser.open(
                     f"https://financialmodelingprep.com/financial-summary/{s_ticker}"
                 )
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "fidelity":
                 webbrowser.open(
                     f"https://eresearch.fidelity.com/eresearch/goto/evaluate/snapshot.jhtml?symbols={s_ticker}"
                 )
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "tradingview":
                 webbrowser.open(f"https://www.tradingview.com/symbols/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "marketchameleon":
                 webbrowser.open(f"https://marketchameleon.com/Overview/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "stockrow":
                 webbrowser.open(f"https://stockrow.com/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "barchart":
                 webbrowser.open(
                     f"https://www.barchart.com/stocks/quotes/{s_ticker}/overview"
                 )
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "grufity":
                 webbrowser.open(f"https://grufity.com/stock/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "fintel":
                 webbrowser.open(f"https://fintel.io/s/us/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "zacks":
                 webbrowser.open(f"https://www.zacks.com/stock/quote/{s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "macrotrends":
                 webbrowser.open(
                     f"https://www.macrotrends.net/stocks/charts/{s_ticker}/{s_ticker}/market-cap"
                 )
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "newsfilter":
                 webbrowser.open(f"https://newsfilter.io/search?query={s_ticker}")
-                print("")
 
-            # ------------------------------------------------------------------------------------------------------------
             elif ns_known_args.cmd == "resources":
                 # webbrowser.open(f"https://www.tradinganalysisresources.com/2020/05/free-references-and-resources.html")
                 webbrowser.open(
                     "https://moongangcapital.com/free-stock-market-resources/"
                 )
 
-                print("")
-
-            # ------------------------------------------------------------------------------------------------------------
             else:
                 print("Command not recognized!")
+
+            print("")
 
         except SystemExit:
             print("")

--- a/gamestonk_terminal/technical_analysis/overlap.py
+++ b/gamestonk_terminal/technical_analysis/overlap.py
@@ -82,7 +82,7 @@ def ema(l_args, s_ticker, s_interval, df_stock):
         plt.plot(df_ta.index, df_ta.values)
         # Pandas series
         if len(df_ta.shape) == 1:
-            l_legend = ["{ns_parser.n_length} EMA"]
+            l_legend = [f"{ns_parser.n_length} EMA"]
         # Pandas dataframe
         else:
             l_legend = df_ta.columns.tolist()

--- a/terminal.py
+++ b/terminal.py
@@ -127,7 +127,7 @@ def main():
             b_quit = sm.sen_menu(s_ticker, s_start)
 
         elif ns_known_args.opt == "res":
-            b_quit = rm.res_menu(s_ticker)
+            b_quit = rm.res_menu(s_ticker, s_start, s_interval)
 
         elif ns_known_args.opt == "fa":
             b_quit = fam.fa_menu(s_ticker, s_start, s_interval)
@@ -163,7 +163,9 @@ def main():
             if s_interval == "1440min":
                 b_quit = pm.pred_menu(df_stock, s_ticker, s_start, s_interval)
             # If stock data is intradaily, we need to get data again as prediction
-            # techniques work on daily adjusted data
+            # techniques work on daily adjusted data. By default we load data from
+            # Alpha Vantage because the historical data loaded gives a larger
+            # dataset than the one provided by quandl
             else:
                 try:
                     ts = TimeSeries(


### PR DESCRIPTION
This PR does several things, the main one is replacing the source of the historical prices when loading a stock.

This is because of 2 things:
- Alpha Vantage restrictions are much harsher than Yahoo Finance
   - AV: 5 API requests per minute; 500 API requests per day
   - Yahoo Finance API requests are limited to 2,000 requests per hour per IP (or up to a total of 48,000 requests a day)
- Yahoo Finance provides stocks on the NSE (India) which has been required by #61

Note: It's still possible to use AV data, but by default YF will be used. The only "issue" with YF is the fact that the data tends to be generally shorter, this shouldn't be a problem anyway because the data provided by YF should be good enough for all functionalities of the terminal.

Note2: If we're playing with intraday data, and we go into prediction menu, we load the adjusted close data from alpha vantage by default. Just because it has a bigger length, and may allow to train the algorithms better. Although this is not always the case, and such training may not even be relevant given the "outdatedecy" of the data.

It also fixes a minor typo on the legend of the EMA plot of prediction

It also refactors research menu, and shows on the menu itself the stock we're dealing with