### PR TITLE
Another go with the prompt_toolkit

### DIFF
--- a/gamestonk_terminal/discovery/disc_menu.py
+++ b/gamestonk_terminal/discovery/disc_menu.py
@@ -1,19 +1,20 @@
 import argparse
-from gamestonk_terminal.discovery import alpha_vantage_api
-from gamestonk_terminal.discovery import yahoo_finance_api
-from gamestonk_terminal.discovery import finviz_api
-from gamestonk_terminal.discovery import short_interest_api
-from gamestonk_terminal.discovery import seeking_alpha_api
-from gamestonk_terminal.discovery import fidelity_api
-from gamestonk_terminal.discovery import ark_api
-from gamestonk_terminal.discovery import simply_wallst_api
-from gamestonk_terminal.discovery import spachero_api
-from gamestonk_terminal.discovery import unusual_whales_api
 
+from gamestonk_terminal.discovery import (
+    alpha_vantage_api,
+    ark_api,
+    fidelity_api,
+    finviz_api,
+    seeking_alpha_api,
+    short_interest_api,
+    simply_wallst_api,
+    spachero_api,
+    unusual_whales_api,
+    yahoo_finance_api,
+)
 from gamestonk_terminal.helper_funcs import get_flair
-
 from gamestonk_terminal.menu import session
-from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.completion import NestedCompleter
 
 
 def print_discovery():
@@ -66,7 +67,7 @@ def disc_menu():
         "mill",
     ]
     disc_parser.add_argument("cmd", choices=choices)
-    word_completer = WordCompleter(choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     print_discovery()
 
@@ -76,7 +77,7 @@ def disc_menu():
         if session:
             as_input = session.prompt(
                 f"{get_flair()} (disc)> ",
-                completer=word_completer,
+                completer=completer,
             )
         else:
             as_input = input(f"{get_flair()} (disc)> ")

--- a/gamestonk_terminal/due_diligence/dd_menu.py
+++ b/gamestonk_terminal/due_diligence/dd_menu.py
@@ -1,13 +1,14 @@
 import argparse
 
+from gamestonk_terminal.due_diligence import business_insider_api as bi_api
+from gamestonk_terminal.due_diligence import financial_modeling_prep_api as fmp_api
 from gamestonk_terminal.due_diligence import finviz_api as fvz_api
 from gamestonk_terminal.due_diligence import market_watch_api as mw_api
-from gamestonk_terminal.due_diligence import reddit_api as r_api
 from gamestonk_terminal.due_diligence import quandl_api as q_api
-from gamestonk_terminal.due_diligence import financial_modeling_prep_api as fmp_api
-from gamestonk_terminal.due_diligence import business_insider_api as bi_api
-
+from gamestonk_terminal.due_diligence import reddit_api as r_api
 from gamestonk_terminal.helper_funcs import get_flair
+from gamestonk_terminal.menu import session
+from prompt_toolkit.completion import NestedCompleter
 
 
 def print_due_diligence(s_ticker, s_start, s_interval):
@@ -48,33 +49,38 @@ def dd_menu(df_stock, s_ticker, s_start, s_interval):
 
     # Add list of arguments that the due diligence parser accepts
     dd_parser = argparse.ArgumentParser(prog="dd", add_help=False)
-    dd_parser.add_argument(
-        "cmd",
-        choices=[
-            "info",
-            "help",
-            "q",
-            "quit",
-            "red",
-            "short",
-            "rating",
-            "pt",
-            "est",
-            "ins",
-            "insider",
-            "news",
-            "analyst",
-            "warnings",
-            "sec",
-        ],
-    )
+    choices = [
+        "info",
+        "help",
+        "q",
+        "quit",
+        "red",
+        "short",
+        "rating",
+        "pt",
+        "est",
+        "ins",
+        "insider",
+        "news",
+        "analyst",
+        "warnings",
+        "sec",
+    ]
+    dd_parser.add_argument("cmd", choices=choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     print_due_diligence(s_ticker, s_start, s_interval)
 
     # Loop forever and ever
     while True:
         # Get input command from user
-        as_input = input(f"{get_flair()} (dd)> ")
+        if session:
+            as_input = session.prompt(
+                f"{get_flair()} (dd)> ",
+                completer=completer,
+            )
+        else:
+            as_input = input(f"{get_flair()} (dd)> ")
 
         # Parse due diligence command of the list of possible commands
         try:

--- a/gamestonk_terminal/fundamental_analysis/fa_menu.py
+++ b/gamestonk_terminal/fundamental_analysis/fa_menu.py
@@ -1,15 +1,16 @@
 import argparse
 
 from gamestonk_terminal.fundamental_analysis import alpha_vantage_api as av_api
+from gamestonk_terminal.fundamental_analysis import business_insider_api as bi_api
 from gamestonk_terminal.fundamental_analysis import (
     financial_modeling_prep_api as fmp_api,
 )
 from gamestonk_terminal.fundamental_analysis import finviz_api as fvz_api
 from gamestonk_terminal.fundamental_analysis import market_watch_api as mw_api
-from gamestonk_terminal.fundamental_analysis import business_insider_api as bi_api
 from gamestonk_terminal.fundamental_analysis import yahoo_finance_api as yf_api
-
 from gamestonk_terminal.helper_funcs import get_flair
+from gamestonk_terminal.menu import session
+from prompt_toolkit.completion import NestedCompleter
 
 
 def print_fundamental_analysis(s_ticker, s_start, s_interval):
@@ -100,49 +101,54 @@ def fa_menu(s_ticker, s_start, s_interval):
 
     # Add list of arguments that the fundamental analysis parser accepts
     fa_parser = argparse.ArgumentParser(prog="fa", add_help=False)
-    fa_parser.add_argument(
-        "cmd",
-        choices=[
-            "help",
-            "q",
-            "quit",
-            "screener",
-            "mgmt",
-            "info",
-            "shrs",
-            "sust",
-            "cal",
-            "income",
-            "assets",
-            "liabilities",
-            "operating",
-            "investing",
-            "financing",
-            "overview",
-            "key",
-            "incom",
-            "balance",
-            "cash",
-            "earnings",
-            "profile",
-            "quote",
-            "enterprise",
-            "dcf",
-            "inc",
-            "bal",
-            "cashf",
-            "metrics",
-            "ratios",
-            "growth",
-        ],
-    )
+    choices = [
+        "help",
+        "q",
+        "quit",
+        "screener",
+        "mgmt",
+        "info",
+        "shrs",
+        "sust",
+        "cal",
+        "income",
+        "assets",
+        "liabilities",
+        "operating",
+        "investing",
+        "financing",
+        "overview",
+        "key",
+        "incom",
+        "balance",
+        "cash",
+        "earnings",
+        "profile",
+        "quote",
+        "enterprise",
+        "dcf",
+        "inc",
+        "bal",
+        "cashf",
+        "metrics",
+        "ratios",
+        "growth",
+    ]
+    fa_parser.add_argument("cmd", choices=choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     print_fundamental_analysis(s_ticker, s_start, s_interval)
 
     # Loop forever and ever
     while True:
         # Get input command from user
-        as_input = input(f"{get_flair()} (fa)> ")
+        if session:
+            as_input = session.prompt(
+                f"{get_flair()} (fa)> ",
+                completer=completer,
+            )
+        else:
+            as_input = input(f"{get_flair()} (fa)> ")
 
         # Parse fundamental analysis command of the list of possible commands
         try:

--- a/gamestonk_terminal/prediction_techniques/pred_menu.py
+++ b/gamestonk_terminal/prediction_techniques/pred_menu.py
@@ -1,15 +1,18 @@
 import argparse
 
-from gamestonk_terminal.prediction_techniques import sma
-from gamestonk_terminal.prediction_techniques import ets
-from gamestonk_terminal.prediction_techniques import knn
-from gamestonk_terminal.prediction_techniques import regression
-from gamestonk_terminal.prediction_techniques import arima
-from gamestonk_terminal.prediction_techniques import fbprophet
-from gamestonk_terminal.prediction_techniques import neural_networks
 import matplotlib.pyplot as plt
-
 from gamestonk_terminal.helper_funcs import get_flair
+from gamestonk_terminal.menu import session
+from gamestonk_terminal.prediction_techniques import (
+    arima,
+    ets,
+    fbprophet,
+    knn,
+    neural_networks,
+    regression,
+    sma,
+)
+from prompt_toolkit.completion import NestedCompleter
 
 
 def print_prediction(s_ticker, s_start, s_interval):
@@ -46,33 +49,38 @@ def pred_menu(df_stock, s_ticker, s_start, s_interval):
 
     # Add list of arguments that the prediction techniques parser accepts
     pred_parser = argparse.ArgumentParser(prog="pred", add_help=False)
-    pred_parser.add_argument(
-        "cmd",
-        choices=[
-            "help",
-            "q",
-            "quit",
-            "sma",
-            "ets",
-            "knn",
-            "linear",
-            "quadratic",
-            "cubic",
-            "regression",
-            "arima",
-            "prophet",
-            "mlp",
-            "rnn",
-            "lstm",
-        ],
-    )
+    choices = [
+        "help",
+        "q",
+        "quit",
+        "sma",
+        "ets",
+        "knn",
+        "linear",
+        "quadratic",
+        "cubic",
+        "regression",
+        "arima",
+        "prophet",
+        "mlp",
+        "rnn",
+        "lstm",
+    ]
+    pred_parser.add_argument("cmd", choices=choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     print_prediction(s_ticker, s_start, s_interval)
 
     # Loop forever and ever
     while True:
         # Get input command from user
-        as_input = input(f"{get_flair()} (pred)> ")
+        if session:
+            as_input = session.prompt(
+                f"{get_flair()} (pred)> ",
+                completer=completer,
+            )
+        else:
+            as_input = input(f"{get_flair()} (pred)> ")
 
         # Images are non blocking - allows to close them if we type other command
         plt.close()

--- a/gamestonk_terminal/sentiment/sen_menu.py
+++ b/gamestonk_terminal/sentiment/sen_menu.py
@@ -1,11 +1,10 @@
 import argparse
-from gamestonk_terminal.sentiment import reddit_api
-from gamestonk_terminal.sentiment import stocktwits_api
-from gamestonk_terminal.sentiment import google_api
 
 from gamestonk_terminal import config_terminal as cfg
-
 from gamestonk_terminal.helper_funcs import get_flair
+from gamestonk_terminal.menu import session
+from gamestonk_terminal.sentiment import google_api, reddit_api, stocktwits_api
+from prompt_toolkit.completion import NestedCompleter
 
 
 # -----------------------------------------------------------------------------------------------------------------------
@@ -51,36 +50,41 @@ def sen_menu(s_ticker, s_start):
 
     # Add list of arguments that the discovery parser accepts
     sen_parser = argparse.ArgumentParser(prog="sen", add_help=False)
-    sen_parser.add_argument(
-        "cmd",
-        choices=[
-            "help",
-            "q",
-            "quit",
-            "watchlist",
-            "spac",
-            "spac_c",
-            "wsb",
-            "popular",
-            "bullbear",
-            "messages",
-            "trending",
-            "stalker",
-            "infer",
-            "sentiment",
-            "mentions",
-            "regions",
-            "queries",
-            "rise",
-        ],
-    )
+    choices = [
+        "help",
+        "q",
+        "quit",
+        "watchlist",
+        "spac",
+        "spac_c",
+        "wsb",
+        "popular",
+        "bullbear",
+        "messages",
+        "trending",
+        "stalker",
+        "infer",
+        "sentiment",
+        "mentions",
+        "regions",
+        "queries",
+        "rise",
+    ]
+    sen_parser.add_argument("cmd", choices=choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     print_sentiment()
 
     # Loop forever and ever
     while True:
         # Get input command from user
-        as_input = input(f"{get_flair()} (sen)> ")
+        if session:
+            as_input = session.prompt(
+                f"{get_flair()} (sen)> ",
+                completer=completer,
+            )
+        else:
+            as_input = input(f"{get_flair()} (sen)> ")
 
         # Parse sentiment command of the list of possible commands
         try:

--- a/gamestonk_terminal/technical_analysis/ta_menu.py
+++ b/gamestonk_terminal/technical_analysis/ta_menu.py
@@ -1,13 +1,14 @@
 import argparse
 
-from gamestonk_terminal.technical_analysis import overlap as ta_overlap
+import matplotlib.pyplot as plt
+from gamestonk_terminal.helper_funcs import get_flair
+from gamestonk_terminal.menu import session
 from gamestonk_terminal.technical_analysis import momentum as ta_momentum
+from gamestonk_terminal.technical_analysis import overlap as ta_overlap
 from gamestonk_terminal.technical_analysis import trend as ta_trend
 from gamestonk_terminal.technical_analysis import volatility as ta_volatility
 from gamestonk_terminal.technical_analysis import volume as ta_volume
-import matplotlib.pyplot as plt
-
-from gamestonk_terminal.helper_funcs import get_flair
+from prompt_toolkit.completion import NestedCompleter
 
 
 def print_technical_analysis(s_ticker, s_start, s_interval):
@@ -48,33 +49,38 @@ def ta_menu(df_stock, s_ticker, s_start, s_interval):
 
     # Add list of arguments that the technical analysis parser accepts
     ta_parser = argparse.ArgumentParser(prog="ta", add_help=False)
-    ta_parser.add_argument(
-        "cmd",
-        choices=[
-            "help",
-            "q",
-            "quit",
-            "ema",
-            "sma",
-            "vwap",
-            "cci",
-            "macd",
-            "rsi",
-            "stoch",
-            "adx",
-            "aroon",
-            "bbands",
-            "ad",
-            "obv",
-        ],
-    )
+    choices = [
+        "help",
+        "q",
+        "quit",
+        "ema",
+        "sma",
+        "vwap",
+        "cci",
+        "macd",
+        "rsi",
+        "stoch",
+        "adx",
+        "aroon",
+        "bbands",
+        "ad",
+        "obv",
+    ]
+    ta_parser.add_argument("cmd", choices=choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     print_technical_analysis(s_ticker, s_start, s_interval)
 
     # Loop forever and ever
     while True:
         # Get input command from user
-        as_input = input(f"{get_flair} (ta)> ")
+        if session:
+            as_input = session.prompt(
+                f"{get_flair()} (ta)> ",
+                completer=completer,
+            )
+        else:
+            as_input = input(f"{get_flair()} (ta)> ")
 
         # Images are non blocking - allows to close them if we type other command
         plt.close()

--- a/terminal.py
+++ b/terminal.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python
 
 import argparse
+
 import pandas as pd
 from alpha_vantage.timeseries import TimeSeries
+from prompt_toolkit.completion import NestedCompleter
 
-from gamestonk_terminal.main_helper import print_help, clear, load, view, export
-from gamestonk_terminal.helper_funcs import b_is_stock_market_open, get_flair
-
-from gamestonk_terminal.fundamental_analysis import fa_menu as fam
-from gamestonk_terminal.technical_analysis import ta_menu as tam
-from gamestonk_terminal.due_diligence import dd_menu as ddm
-from gamestonk_terminal.discovery import disc_menu as dm
-from gamestonk_terminal.sentiment import sen_menu as sm
-from gamestonk_terminal.papermill import papermill_menu as mill
-from gamestonk_terminal import res_menu as rm
 from gamestonk_terminal import config_terminal as cfg
+from gamestonk_terminal import res_menu as rm
+from gamestonk_terminal.discovery import disc_menu as dm
+from gamestonk_terminal.due_diligence import dd_menu as ddm
+from gamestonk_terminal.fundamental_analysis import fa_menu as fam
+from gamestonk_terminal.helper_funcs import b_is_stock_market_open, get_flair
+from gamestonk_terminal.main_helper import clear, export, load, print_help, view
 from gamestonk_terminal.menu import session
-from prompt_toolkit.completion import WordCompleter
-
+from gamestonk_terminal.papermill import papermill_menu as mill
+from gamestonk_terminal.sentiment import sen_menu as sm
+from gamestonk_terminal.technical_analysis import ta_menu as tam
 
 # import warnings
 # warnings.simplefilter("always")
@@ -63,7 +62,7 @@ def main():
         "pred",
     ]
     menu_parser.add_argument("opt", choices=choices)
-    word_completer = WordCompleter(choices)
+    completer = NestedCompleter.from_nested_dict({c: None for c in choices})
 
     # Print first welcome message and help
     print("")
@@ -79,10 +78,10 @@ def main():
             should_print_help = False
 
         # Get input command from user
-        as_input = session.prompt(
-            f"{get_flair()}> ",
-            completer=word_completer,
-        )
+        if session:
+            as_input = session.prompt(f"{get_flair()}> ", completer=completer)
+        else:
+            as_input = input(f"{get_flair()}> ")
 
         # Is command empty
         if not as_input:


### PR DESCRIPTION
I expanded the history and autocomplete to the other menus.
Also, I added nested dictionaries for word completion. Right now every command is atomic. There's no other suggestions once you type the first word.

**TODO**:
Add autocomplete to the command options, e.g.,: `view [-h] -t S_TICKER [-s S_START_DATE] [-i {1,5,15,30,60}] [--type TYPE]`

I also used VSCODE "organize imports"... Sorry for the mess in the PR.