### PR TITLE
Backtesting prediction

### DIFF
--- a/gamestonk_terminal/README.md
+++ b/gamestonk_terminal/README.md
@@ -36,6 +36,13 @@ view -t S_TICKER [-s S_START_DATE] [-i {1,5,15,30,60}] [--type N_TYPE]
 ![GNUS](https://user-images.githubusercontent.com/25267873/108925137-f2920e80-7633-11eb-8274-6e3bb6a19592.png)
 
 ```
+candle
+```
+  * Visualize candles historical data from the past 6 months, with support and resistance bars, and moving averages of 20 and 50
+
+![nio](https://user-images.githubusercontent.com/25267873/111053397-4d609e00-845b-11eb-9c94-89b8892a8e81.png)
+
+```
 export -f GNUS_data -F csv
 ```
    * Exports the historical data from this ticker to a file or stdout.

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -8,7 +8,6 @@ import iso8601
 import matplotlib.pyplot as plt
 from holidays import US as holidaysUS
 from colorama import Fore, Style
-import pandas as pd
 import pandas.io.formats.format
 from pandas._config.config import get_option
 from pandas.plotting import register_matplotlib_converters
@@ -289,25 +288,6 @@ def parse_known_args_and_warn(parser, l_args):
         print(f"The following args couldn't be interpreted: {l_unknown_args}")
 
     return ns_parser
-
-
-def price_prediction_color(val: int, last_val: int) -> str:
-    if float(val) > last_val:
-        color = Fore.GREEN
-    else:
-        color = Fore.RED
-    return f"{color}{val:.2f} ${Style.RESET_ALL}"
-
-
-def print_pretty_prediction(df_pred: pd.DataFrame, last_price: float):
-    if gtff.USE_COLOR:
-        print(f"Actual price: {Fore.YELLOW}{last_price:.2f} ${Style.RESET_ALL}\n")
-        print("Prediction:")
-        print(df_pred.apply(price_prediction_color, last_val=last_price).to_string())
-    else:
-        print(f"Actual price: {last_price:.2f} $\n")
-        print("Prediction:")
-        print(df_pred.to_string())
 
 
 def financials_colored_values(val: str) -> str:

--- a/gamestonk_terminal/prediction_techniques/README.md
+++ b/gamestonk_terminal/prediction_techniques/README.md
@@ -26,6 +26,7 @@ This menu aims to predict the share price of a pre-loaded stock, and the usage o
     - Recurrent Neural Network
   * [lstm](#lstm)
     - Long-Short Term Memory
+    - Contains a [backtesting example](#backtesting)
 
 **Note:** _Use this at your own discretion. All of these prediciton techniques rely solely on the closing price of the stock. This means that there are several factors that the models aren't aware of at the time of prediction, and may - drastically - move the price up or down. Examples are: news, analyst price targets, reddit post, tweets from Elon Musk, and so on._
 
@@ -37,6 +38,7 @@ usage: sma [-l N_LENGTH] [-d N_DAYS]
 Simple Moving Average:
   * -l : length of SMA window. Default 20.
   * -d : prediciton days. Default 5.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![sma](https://user-images.githubusercontent.com/25267873/108604945-d29aea80-73a8-11eb-8dac-6a545b9c52b9.png)
 
@@ -49,6 +51,7 @@ Exponential Smoothing (based on trend+seasonality, see https://otexts.com/fpp2/t
   * -s : seasonality component: N: None, A: Additive, M: Multiplicative. Default N.
   * -p : seasonal periods. Default 5.
   * -d : prediciton days. Default 5.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![ets_pltr](https://user-images.githubusercontent.com/25267873/110266847-97a6d280-7fb6-11eb-997e-0b598abc713b.png)
 
@@ -61,6 +64,7 @@ k-Nearest Neighbors:
   * -d : prediciton days. Default 5.
   * -j : number of jumps in training data. Default 1.
   * -n : number of neighbors to use on the algorithm. Default 20.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![knn](https://user-images.githubusercontent.com/25267873/108604942-d169bd80-73a8-11eb-9021-6f787cbd41e3.png)
 
@@ -73,6 +77,7 @@ Linear Regression (p=1):
   * -i : number of days to use for prediction. Default 40.
   * -d : prediciton days. Default 5.
   * -j : number of jumps in training data. Default 1.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![linear](https://user-images.githubusercontent.com/25267873/108604948-d3cc1780-73a8-11eb-860f-49274a34038b.png)
 
@@ -85,6 +90,7 @@ Quadratic Regression (p=2):
   * -i : number of days to use for prediction. Default 40.
   * -d : prediciton days. Default 5.
   * -j : number of jumps in training data. Default 1.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![quadratic](https://user-images.githubusercontent.com/25267873/108604935-cca50980-73a8-11eb-9af1-bba807203cc6.png)
 
@@ -97,6 +103,7 @@ Cubic Regression (p=3):
   * -i : number of days to use for prediction. Default 40.
   * -d : prediciton days. Default 5.
   * -j : number of jumps in training data. Default 1.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![cubic](https://user-images.githubusercontent.com/25267873/108604941-d169bd80-73a8-11eb-9220-84a7013e1283.png)
 
@@ -109,6 +116,7 @@ Regression:
   * -d : prediciton days. Default 5.
   * -j : number of jumps in training data. Default 1.
   * -p : polynomial associated with regression. Required.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![regression](https://user-images.githubusercontent.com/25267873/108604946-d3338100-73a8-11eb-9e99-fa526fb56672.png)
 
@@ -125,6 +133,7 @@ Auto-Regressive Integrated Moving Average:
     * p = 5 : order (number of time lags) of the autoregressive model.
     * d = 1 : degree of differencing (the number of times the data have had past values subtracted).
     * q = 4 : order of the moving-average model.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![arima](https://user-images.githubusercontent.com/25267873/108604947-d3cc1780-73a8-11eb-9dbb-53b959ae7947.png)
 
@@ -134,6 +143,7 @@ usage: fbprophet [-d N_DAYS]
 ```
 Facebook's Prophet:
   * -d : prediciton days. Default 5.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 ![prophet](https://user-images.githubusercontent.com/25267873/108604938-cf9ffa00-73a8-11eb-973b-0affb343e2f6.png)
 
@@ -146,10 +156,11 @@ MulitLayer Perceptron:
   * -d : prediciton days. Default 5.
   * -i : number of days to use for prediction. Default 40.
   * -j : number of jumps in training data. Default 1.
-  * -e : number of training epochs. Default 200.
+  * --epochs : number of training epochs. Default 200.
   * -p : pre-processing data. Default normalization.
   * -o : optimization technique. Default adam.
   * -l : loss function. Default mae.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 Due to the complexity of defining a model through command line, one can define it in: [config_neural_network_models.txt](/config_neural_network_models.py)
 ```
@@ -177,10 +188,11 @@ Recurrent Neural Network:
   * -d : prediciton days. Default 5.
   * -i : number of days to use for prediction. Default 40.
   * -j : number of jumps in training data. Default 1.
-  * -e : number of training epochs. Default 200.
+  * --epochs : number of training epochs. Default 200.
   * -p : pre-processing data. Default normalization.
   * -o : optimization technique. Default adam.
   * -l : loss function. Default mae.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 Due to the complexity of defining a model through command line, one can define it in: [config_neural_network_models.txt](/config_neural_network_models.py)
 ```
@@ -208,10 +220,11 @@ Long-Short Term Memory:
   * -d : prediciton days. Default 5.
   * -i : number of days to use for prediction. Default 40.
   * -j : number of jumps in training data. Default 1.
-  * -e : number of training epochs. Default 200.
+  * --epochs : number of training epochs. Default 200.
   * -p : pre-processing data. Default normalization.
   * -o : optimization technique. Default adam.
   * -l : loss function. Default mae.
+  * -e : end date (format YYYY-MM-DD) of the stock - Backtesting. Default None.
 
 Due to the complexity of defining a model through command line, one can define it in: [config_neural_network_models.txt](/config_neural_network_models.py)
 ```
@@ -226,4 +239,11 @@ Long_Short_Term_Memory \
 
 ![lstm](https://user-images.githubusercontent.com/25267873/108604943-d2025400-73a8-11eb-83c5-edb4a2121cba.png)
 
+### Backtesting Exmaple <a name="backtesting"></a>
+
+![appl_pred](https://user-images.githubusercontent.com/25267873/111053156-4173dc80-8459-11eb-9fcb-e81211961743.png)
+
+![apple_error](https://user-images.githubusercontent.com/25267873/111053157-420c7300-8459-11eb-8c37-fb1b5208d635.png)
+
+<img width="992" alt="Captura de ecrã 2021-03-14, às 00 06 51" src="https://user-images.githubusercontent.com/25267873/111053158-420c7300-8459-11eb-993b-6d9c26f98af9.png">
 

--- a/gamestonk_terminal/prediction_techniques/README.md
+++ b/gamestonk_terminal/prediction_techniques/README.md
@@ -239,7 +239,7 @@ Long_Short_Term_Memory \
 
 ![lstm](https://user-images.githubusercontent.com/25267873/108604943-d2025400-73a8-11eb-83c5-edb4a2121cba.png)
 
-### Backtesting Exmaple <a name="backtesting"></a>
+### Backtesting Example <a name="backtesting"></a>
 
 ![appl_pred](https://user-images.githubusercontent.com/25267873/111053156-4173dc80-8459-11eb-9fcb-e81211961743.png)
 

--- a/gamestonk_terminal/prediction_techniques/arima.py
+++ b/gamestonk_terminal/prediction_techniques/arima.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import matplotlib.pyplot as plt
 import pandas as pd
 from pandas.plotting import register_matplotlib_converters
@@ -6,9 +7,15 @@ import pmdarima
 from statsmodels.tsa.arima.model import ARIMA
 from gamestonk_terminal.helper_funcs import (
     check_positive,
-    get_next_stock_market_days,
     parse_known_args_and_warn,
+    valid_date,
+    patch_pandas_text_adjustment,
+    get_next_stock_market_days,
+)
+from gamestonk_terminal.prediction_techniques.pred_helper import (
     print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
 )
 
 from gamestonk_terminal import feature_flags as gtff
@@ -75,11 +82,53 @@ def arima(l_args, s_ticker, df_stock):
         default=False,
         help="results about ARIMA summary flag.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=5 + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         # Machine Learning model
         if ns_parser.s_order:
@@ -122,13 +171,25 @@ def arima(l_args, s_ticker, df_stock):
         plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=2)
         if ns_parser.s_order:
-            plt.title(
-                f"ARIMA {str(t_order)} on {s_ticker} - {ns_parser.n_days} days prediction"
-            )
+            # BACKTESTING
+            if ns_parser.s_end_date:
+                plt.title(
+                    f"BACKTESTING: ARIMA {str(t_order)} on {s_ticker} - {ns_parser.n_days} days prediction"
+                )
+            else:
+                plt.title(
+                    f"ARIMA {str(t_order)} on {s_ticker} - {ns_parser.n_days} days prediction"
+                )
         else:
-            plt.title(
-                f"ARIMA {model.order} on {s_ticker} - {ns_parser.n_days} days prediction"
-            )
+            # BACKTESTING
+            if ns_parser.s_end_date:
+                plt.title(
+                    f"BACKTESTING: ARIMA {model.order} on {s_ticker} - {ns_parser.n_days} days prediction"
+                )
+            else:
+                plt.title(
+                    f"ARIMA {model.order} on {s_ticker} - {ns_parser.n_days} days prediction"
+                )
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -153,13 +214,149 @@ def arima(l_args, s_ticker, df_stock):
             df_stock.index[-1], ymin, ymax, linewidth=1, linestyle="--", color="k"
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:

--- a/gamestonk_terminal/prediction_techniques/ets.py
+++ b/gamestonk_terminal/prediction_techniques/ets.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -6,9 +7,15 @@ from pandas.plotting import register_matplotlib_converters
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 from gamestonk_terminal.helper_funcs import (
     check_positive,
-    get_next_stock_market_days,
     parse_known_args_and_warn,
+    valid_date,
+    patch_pandas_text_adjustment,
+    get_next_stock_market_days,
+)
+from gamestonk_terminal.prediction_techniques.pred_helper import (
     print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
 )
 
 from gamestonk_terminal import feature_flags as gtff
@@ -94,12 +101,55 @@ def exponential_smoothing(l_args, s_ticker, df_stock):
         default=5,
         help="Seasonal periods.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=5 + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
+
+        # Get ETS model
         model, title = get_exponential_smoothing_model(
             df_stock["5. adjusted close"].values,
             ns_parser.trend,
@@ -131,7 +181,11 @@ def exponential_smoothing(l_args, s_ticker, df_stock):
                 # Plotting
                 plt.figure()
                 plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=2)
-                plt.title(f"{title} on {s_ticker}")
+                # BACKTESTING
+                if ns_parser.s_end_date:
+                    plt.title(f"BACKTESTING: {title} on {s_ticker}")
+                else:
+                    plt.title(f"{title} on {s_ticker}")
 
                 plt.xlim(
                     df_stock.index[0],
@@ -168,15 +222,161 @@ def exponential_smoothing(l_args, s_ticker, df_stock):
                     color="k",
                 )
 
+                # BACKTESTING
+                if ns_parser.s_end_date:
+                    plt.plot(
+                        df_future.index,
+                        df_future["5. adjusted close"],
+                        lw=2,
+                        c="tab:blue",
+                        ls="--",
+                    )
+                    plt.plot(
+                        [df_stock.index[-1], df_future.index[0]],
+                        [
+                            df_stock["5. adjusted close"].values[-1],
+                            df_future["5. adjusted close"].values[0],
+                        ],
+                        lw=1,
+                        c="tab:blue",
+                        linestyle="--",
+                    )
+
                 if gtff.USE_ION:
                     plt.ion()
 
                 plt.show()
 
-                # Print prediction data
-                print_pretty_prediction(
-                    df_pred, df_stock["5. adjusted close"].values[-1]
-                )
+                # BACKTESTING
+                if ns_parser.s_end_date:
+                    plt.figure()
+                    plt.subplot(211)
+                    plt.plot(
+                        df_future.index,
+                        df_future["5. adjusted close"],
+                        lw=2,
+                        c="tab:blue",
+                        ls="--",
+                    )
+                    plt.plot(df_pred.index, df_pred, lw=2, c="green")
+                    plt.scatter(
+                        df_future.index,
+                        df_future["5. adjusted close"],
+                        c="tab:blue",
+                        lw=3,
+                    )
+                    plt.plot(
+                        [df_stock.index[-1], df_future.index[0]],
+                        [
+                            df_stock["5. adjusted close"].values[-1],
+                            df_future["5. adjusted close"].values[0],
+                        ],
+                        lw=2,
+                        c="tab:blue",
+                        ls="--",
+                    )
+                    plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+                    plt.plot(
+                        [df_stock.index[-1], df_pred.index[0]],
+                        [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                        lw=2,
+                        c="green",
+                        ls="--",
+                    )
+                    plt.title("BACKTESTING: Real data price versus Prediction")
+                    plt.xlim(
+                        df_stock.index[-1],
+                        df_pred.index[-1] + datetime.timedelta(days=1),
+                    )
+                    plt.ylabel("Share Price ($)")
+                    plt.grid(b=True, which="major", color="#666666", linestyle="-")
+                    plt.minorticks_on()
+                    plt.grid(
+                        b=True, which="minor", color="#999999", linestyle="-", alpha=0.2
+                    )
+                    plt.legend(["Real data", "Prediction data"])
+                    plt.xticks([])
+
+                    plt.subplot(212)
+                    plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+                    plt.plot(
+                        df_future.index,
+                        100
+                        * (df_pred.values - df_future["5. adjusted close"].values)
+                        / df_future["5. adjusted close"].values,
+                        lw=2,
+                        c="red",
+                    )
+                    plt.scatter(
+                        df_future.index,
+                        100
+                        * (df_pred.values - df_future["5. adjusted close"].values)
+                        / df_future["5. adjusted close"].values,
+                        c="red",
+                        lw=5,
+                    )
+                    plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+                    plt.plot(
+                        [df_stock.index[-1], df_future.index[0]],
+                        [
+                            0,
+                            100
+                            * (
+                                df_pred.values[0]
+                                - df_future["5. adjusted close"].values[0]
+                            )
+                            / df_future["5. adjusted close"].values[0],
+                        ],
+                        lw=2,
+                        ls="--",
+                        c="red",
+                    )
+                    plt.xlim(
+                        df_stock.index[-1],
+                        df_pred.index[-1] + datetime.timedelta(days=1),
+                    )
+                    plt.xlabel("Time")
+                    plt.ylabel("Prediction Error (%)")
+                    plt.grid(b=True, which="major", color="#666666", linestyle="-")
+                    plt.minorticks_on()
+                    plt.grid(
+                        b=True, which="minor", color="#999999", linestyle="-", alpha=0.2
+                    )
+                    plt.legend(["Real data", "Prediction data"])
+
+                    if gtff.USE_ION:
+                        plt.ion()
+
+                    plt.show()
+
+                    # Refactor prediction dataframe for backtesting print
+                    df_pred.name = "Prediction"
+                    df_pred = df_pred.to_frame()
+                    df_pred["Real"] = df_future["5. adjusted close"]
+
+                    if gtff.USE_COLOR:
+
+                        patch_pandas_text_adjustment()
+
+                        print("Time         Real [$]  x  Prediction [$]")
+                        print(
+                            df_pred.apply(
+                                price_prediction_backtesting_color, axis=1
+                            ).to_string()
+                        )
+                    else:
+                        print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+                    print("")
+                    print_prediction_kpis(
+                        df_pred["Real"].values, df_pred["Prediction"].values
+                    )
+
+                else:
+                    # Print prediction data
+                    print_pretty_prediction(
+                        df_pred, df_stock["5. adjusted close"].values[-1]
+                    )
                 print("")
 
             else:

--- a/gamestonk_terminal/prediction_techniques/fbprophet.py
+++ b/gamestonk_terminal/prediction_techniques/fbprophet.py
@@ -13,7 +13,6 @@ from gamestonk_terminal.helper_funcs import (
     patch_pandas_text_adjustment,
 )
 from gamestonk_terminal.prediction_techniques.pred_helper import (
-    print_pretty_prediction,
     price_prediction_backtesting_color,
     print_prediction_kpis,
 )

--- a/gamestonk_terminal/prediction_techniques/fbprophet.py
+++ b/gamestonk_terminal/prediction_techniques/fbprophet.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import warnings
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -8,6 +9,13 @@ from gamestonk_terminal.helper_funcs import (
     check_positive,
     get_next_stock_market_days,
     parse_known_args_and_warn,
+    valid_date,
+    patch_pandas_text_adjustment,
+)
+from gamestonk_terminal.prediction_techniques.pred_helper import (
+    print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
 )
 
 from gamestonk_terminal import feature_flags as gtff
@@ -38,11 +46,53 @@ def fbprophet(l_args, s_ticker, df_stock):
         default=5,
         help="prediction days",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=5 + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         df_stock = df_stock.sort_index(ascending=True)
         df_stock.reset_index(level=0, inplace=True)
@@ -60,8 +110,18 @@ def fbprophet(l_args, s_ticker, df_stock):
         close_prices = model.make_future_dataframe(periods=ns_parser.n_days)
         forecast = model.predict(close_prices)
 
+        df_pred = forecast["yhat"][
+            -ns_parser.n_days :
+        ]  # .apply(lambda x: f"{x:.2f} $")
+        df_pred.index = l_pred_days
+
         _, ax = plt.subplots()
-        model.plot(forecast, ax=ax, xlabel="Time", ylabel="Share Price ($)")
+        model.plot(
+            forecast[: -ns_parser.n_days],
+            ax=ax,
+            xlabel="Time",
+            ylabel="Share Price ($)",
+        )
         _, _, ymin, ymax = ax.axis()
         ax.vlines(
             df_stock["ds"].values[-1],
@@ -77,23 +137,165 @@ def fbprophet(l_args, s_ticker, df_stock):
             facecolor="tab:orange",
             alpha=0.2,
         )
-        print("here3")
         plt.ylim(ymin, ymax)
         plt.xlim(
             df_stock["ds"].values[0], get_next_stock_market_days(l_pred_days[-1], 1)[-1]
         )
-        plt.title(f"Fb Prophet on {s_ticker} - {ns_parser.n_days} days prediction")
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: Fb Prophet on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(f"Fb Prophet on {s_ticker} - {ns_parser.n_days} days prediction")
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock["ds"].values[-1], df_future.index[0]],
+                [
+                    df_stock["y"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
+        plt.plot(df_pred.index, df_pred.values, lw=2, c="green")
 
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        print("")
-        print("Predicted share price:")
-        df_pred = forecast["yhat"][-ns_parser.n_days :].apply(lambda x: f"{x:.2f} $")
-        df_pred.index = l_pred_days
-        print(df_pred.to_string())
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index,
+                df_future["5. adjusted close"],
+                c="tab:blue",
+                lw=3,
+            )
+            plt.plot(
+                [df_stock["ds"].values[-1], df_future.index[0]],
+                [
+                    df_stock["y"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock["ds"].values[-1], df_pred.index[0]],
+                [df_stock["y"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(
+                df_stock["ds"].values[-1],
+                df_pred.index[-1] + datetime.timedelta(days=1),
+            )
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock["ds"].values[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(
+                df_stock["ds"].values[-1],
+                df_pred.index[-1] + datetime.timedelta(days=1),
+            )
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+        else:
+            print("")
+            print("Predicted share price:")
+            print(df_pred.to_string())
         print("")
 
     except Exception as e:

--- a/gamestonk_terminal/prediction_techniques/knn.py
+++ b/gamestonk_terminal/prediction_techniques/knn.py
@@ -88,19 +88,16 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
 
         # BACKTESTING
         if ns_parser.s_end_date:
-
             if ns_parser.s_end_date < df_stock.index[0]:
                 print(
                     "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
                 )
                 return
 
-            if (
-                ns_parser.s_end_date
-                < get_next_stock_market_days(
-                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
-                )[-1]
-            ):
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=df_stock.index[0],
+                n_next_days=ns_parser.n_inputs + ns_parser.n_days,
+            )[-1]:
                 print(
                     "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
                 )
@@ -150,13 +147,10 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=2)
         # BACKTESTING
         if ns_parser.s_end_date:
-            plt.title(
-                f"BACKTESTING: {ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker} - {ns_parser.n_days} days prediction"
-            )
+            s_knn = f"{ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker}"
+            plt.title(f"BACKTESTING: {s_knn} - {ns_parser.n_days} days prediction")
         else:
-            plt.title(
-                f"{ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker} - {ns_parser.n_days} days prediction"
-            )
+            plt.title(f"{s_knn} - {ns_parser.n_days} days prediction")
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -241,7 +235,9 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
             )
             plt.title("BACKTESTING: Real data price versus Prediction")
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)]
+            )
             plt.ylabel("Share Price ($)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
@@ -281,7 +277,9 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
                 c="red",
             )
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)]
+            )
             plt.xlabel("Time")
             plt.ylabel("Prediction Error (%)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
@@ -300,7 +298,6 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
             df_pred["Real"] = df_future["5. adjusted close"]
 
             if gtff.USE_COLOR:
-
                 patch_pandas_text_adjustment()
 
                 print("Time         Real [$]  x  Prediction [$]")

--- a/gamestonk_terminal/prediction_techniques/knn.py
+++ b/gamestonk_terminal/prediction_techniques/knn.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import matplotlib.pyplot as plt
 import pandas as pd
 from pandas.plotting import register_matplotlib_converters
@@ -6,10 +7,17 @@ from sklearn import neighbors
 from TimeSeriesCrossValidation import splitTrain
 from gamestonk_terminal.helper_funcs import (
     check_positive,
-    get_next_stock_market_days,
     parse_known_args_and_warn,
-    print_pretty_prediction,
+    valid_date,
+    patch_pandas_text_adjustment,
+    get_next_stock_market_days,
 )
+from gamestonk_terminal.prediction_techniques.pred_helper import (
+    print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
+)
+
 
 from gamestonk_terminal import feature_flags as gtff
 
@@ -63,11 +71,53 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
         default=20,
         help="number of neighbors to use on the algorithm.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         # Split training data
         stock_x, stock_y = splitTrain.split_train(
@@ -76,6 +126,10 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
             ns_parser.n_days,
             ns_parser.n_jumps,
         )
+
+        if not stock_x:
+            print("Given the model parameters more training data is needed.\n")
+            return
 
         # Machine Learning model
         knn = neighbors.KNeighborsRegressor(n_neighbors=ns_parser.n_neighbors)
@@ -94,9 +148,15 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
         # Plotting
         plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=2)
-        plt.title(
-            f"{ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker} - {ns_parser.n_days} days prediction"
-        )
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: {ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(
+                f"{ns_parser.n_neighbors}-Nearest Neighbors on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -121,13 +181,143 @@ def k_nearest_neighbors(l_args, s_ticker, df_stock):
             df_stock.index[-1], ymin, ymax, linewidth=1, linestyle="--", color="k"
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:

--- a/gamestonk_terminal/prediction_techniques/neural_networks.py
+++ b/gamestonk_terminal/prediction_techniques/neural_networks.py
@@ -374,7 +374,10 @@ def mlp(l_args, s_ticker, df_stock):
             )
             plt.title("BACKTESTING: Real data price versus Prediction")
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.ylabel("Share Price ($)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
@@ -414,7 +417,10 @@ def mlp(l_args, s_ticker, df_stock):
                 c="red",
             )
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.xlabel("Time")
             plt.ylabel("Prediction Error (%)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
@@ -747,7 +753,10 @@ def rnn(l_args, s_ticker, df_stock):
             )
             plt.title("BACKTESTING: Real data price versus Prediction")
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.ylabel("Share Price ($)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
@@ -787,7 +796,10 @@ def rnn(l_args, s_ticker, df_stock):
                 c="red",
             )
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.xlabel("Time")
             plt.ylabel("Prediction Error (%)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
@@ -1120,7 +1132,10 @@ def lstm(l_args, s_ticker, df_stock):
             )
             plt.title("BACKTESTING: Real data price versus Prediction")
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.ylabel("Share Price ($)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
@@ -1160,7 +1175,10 @@ def lstm(l_args, s_ticker, df_stock):
                 c="red",
             )
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.xlabel("Time")
             plt.ylabel("Prediction Error (%)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")

--- a/gamestonk_terminal/prediction_techniques/neural_networks.py
+++ b/gamestonk_terminal/prediction_techniques/neural_networks.py
@@ -186,12 +186,10 @@ def mlp(l_args, s_ticker, df_stock):
                 )
                 return
 
-            if (
-                ns_parser.s_end_date
-                < get_next_stock_market_days(
-                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
-                )[-1]
-            ):
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=df_stock.index[0],
+                n_next_days=ns_parser.n_inputs + ns_parser.n_days,
+            )[-1]:
                 print(
                     "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
                 )
@@ -561,12 +559,10 @@ def rnn(l_args, s_ticker, df_stock):
                 )
                 return
 
-            if (
-                ns_parser.s_end_date
-                < get_next_stock_market_days(
-                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
-                )[-1]
-            ):
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=df_stock.index[0],
+                n_next_days=ns_parser.n_inputs + ns_parser.n_days,
+            )[-1]:
                 print(
                     "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
                 )
@@ -936,12 +932,10 @@ def lstm(l_args, s_ticker, df_stock):
                 )
                 return
 
-            if (
-                ns_parser.s_end_date
-                < get_next_stock_market_days(
-                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
-                )[-1]
-            ):
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=df_stock.index[0],
+                n_next_days=ns_parser.n_inputs + ns_parser.n_days,
+            )[-1]:
                 print(
                     "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
                 )

--- a/gamestonk_terminal/prediction_techniques/neural_networks.py
+++ b/gamestonk_terminal/prediction_techniques/neural_networks.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import os
 from warnings import simplefilter
 import numpy as np
@@ -12,10 +13,18 @@ from tensorflow.keras.layers import LSTM, SimpleRNN, Dense, Dropout
 
 from gamestonk_terminal.helper_funcs import (
     check_positive,
-    get_next_stock_market_days,
     parse_known_args_and_warn,
-    print_pretty_prediction,
+    valid_date,
+    patch_pandas_text_adjustment,
+    get_next_stock_market_days,
 )
+
+from gamestonk_terminal.prediction_techniques.pred_helper import (
+    print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
+)
+
 
 from gamestonk_terminal import feature_flags as gtff
 
@@ -29,7 +38,6 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 simplefilter(action="ignore", category=FutureWarning)
 
 
-# ----------------------------------------------------------------------------------------------------
 def build_neural_network_model(Recurrent_Neural_Network, n_inputs, n_days):
     model = Sequential()
 
@@ -101,7 +109,6 @@ def mlp(l_args, s_ticker, df_stock):
         help="number of days to use for prediction.",
     )
     parser.add_argument(
-        "-e",
         "--epochs",
         action="store",
         dest="n_epochs",
@@ -155,11 +162,53 @@ def mlp(l_args, s_ticker, df_stock):
         choices=["mae", "mape", "mse", "msle"],
         help="loss function.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         # Pre-process data
         if ns_parser.s_preprocessing == "standardization":
@@ -184,6 +233,11 @@ def mlp(l_args, s_ticker, df_stock):
             ns_parser.n_days,
             numJumps=ns_parser.n_jumps,
         )
+
+        if not stock_x:
+            print("Given the model parameters more training data is needed.\n")
+            return
+
         stock_x = np.array(stock_x)
         stock_x = np.reshape(stock_x, (stock_x.shape[0], stock_x.shape[1]))
         stock_y = np.array(stock_y)
@@ -225,7 +279,13 @@ def mlp(l_args, s_ticker, df_stock):
         # Plotting
         plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=3)
-        plt.title(f"MLP on {s_ticker} - {ns_parser.n_days} days prediction")
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: MLP on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(f"MLP on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -256,13 +316,143 @@ def mlp(l_args, s_ticker, df_stock):
             color="k",
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:
@@ -294,7 +484,6 @@ def rnn(l_args, s_ticker, df_stock):
         help="number of days to use for prediction.",
     )
     parser.add_argument(
-        "-e",
         "--epochs",
         action="store",
         dest="n_epochs",
@@ -348,11 +537,53 @@ def rnn(l_args, s_ticker, df_stock):
         choices=["mae", "mape", "mse", "msle"],
         help="loss function.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         # Pre-process data
         if ns_parser.s_preprocessing == "standardization":
@@ -377,6 +608,11 @@ def rnn(l_args, s_ticker, df_stock):
             ns_parser.n_days,
             numJumps=ns_parser.n_jumps,
         )
+
+        if not stock_x:
+            print("Given the model parameters more training data is needed.\n")
+            return
+
         stock_x = np.array(stock_x)
         stock_x = np.reshape(stock_x, (stock_x.shape[0], stock_x.shape[1], 1))
         stock_y = np.array(stock_y)
@@ -418,7 +654,13 @@ def rnn(l_args, s_ticker, df_stock):
         # Plotting
         plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=3)
-        plt.title(f"RNN on {s_ticker} - {ns_parser.n_days} days prediction")
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: RNN on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(f"RNN on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -449,13 +691,143 @@ def rnn(l_args, s_ticker, df_stock):
             color="k",
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:
@@ -487,7 +859,6 @@ def lstm(l_args, s_ticker, df_stock):
         help="number of days to use for prediction.",
     )
     parser.add_argument(
-        "-e",
         "--epochs",
         action="store",
         dest="n_epochs",
@@ -541,11 +912,53 @@ def lstm(l_args, s_ticker, df_stock):
         choices=["mae", "mape", "mse", "msle"],
         help="loss function.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         # Pre-process data
         if ns_parser.s_preprocessing == "standardization":
@@ -570,6 +983,11 @@ def lstm(l_args, s_ticker, df_stock):
             ns_parser.n_days,
             numJumps=ns_parser.n_jumps,
         )
+
+        if not stock_x:
+            print("Given the model parameters more training data is needed.\n")
+            return
+
         stock_x = np.array(stock_x)
         stock_x = np.reshape(stock_x, (stock_x.shape[0], stock_x.shape[1], 1))
         stock_y = np.array(stock_y)
@@ -611,7 +1029,13 @@ def lstm(l_args, s_ticker, df_stock):
         # Plotting
         plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=3)
-        plt.title(f"LSTM on {s_ticker} - {ns_parser.n_days} days prediction")
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: LSTM on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(f"LSTM on {s_ticker} - {ns_parser.n_days} days prediction")
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -642,13 +1066,143 @@ def lstm(l_args, s_ticker, df_stock):
             color="k",
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -5,7 +5,6 @@ from gamestonk_terminal import feature_flags as gtff
 import sklearn
 from sklearn.metrics import (
     mean_absolute_error,
-    mean_squared_error,
     r2_score,
     mean_squared_error,
 )

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pandas as pd
+from colorama import Fore, Style
+from gamestonk_terminal import feature_flags as gtff
+from sklearn.metrics import (
+    mean_absolute_error,
+    mean_squared_error,
+    r2_score,
+    mean_squared_error,
+)
+
+
+def get_next_stock_market_days(last_stock_day, n_next_days) -> list:
+    n_days = 0
+    l_pred_days = list()
+    while n_days < n_next_days:
+
+        last_stock_day += timedelta(hours=24)
+
+        # Check if it is a weekend
+        if last_stock_day.date().weekday() > 4:
+            continue
+        # Check if it is a holiday
+        if last_stock_day.strftime("%Y-%m-%d") in holidaysUS():
+            continue
+        # Otherwise stock market is open
+        n_days += 1
+        l_pred_days.append(last_stock_day)
+
+    return l_pred_days
+
+
+def price_prediction_color(val: int, last_val: int) -> str:
+    if float(val) > last_val:
+        color = Fore.GREEN
+    else:
+        color = Fore.RED
+    return f"{color}{val:.2f} ${Style.RESET_ALL}"
+
+
+def print_pretty_prediction(df_pred: pd.DataFrame, last_price: float):
+    if gtff.USE_COLOR:
+        print(f"Actual price: {Fore.YELLOW}{last_price:.2f} ${Style.RESET_ALL}\n")
+        print("Prediction:")
+        print(df_pred.apply(price_prediction_color, last_val=last_price).to_string())
+    else:
+        print(f"Actual price: {last_price:.2f} $\n")
+        print("Prediction:")
+        print(df_pred.to_string())
+
+
+def mean_absolute_percentage_error(y_true, y_pred):
+    y_true, y_pred = np.array(y_true), np.array(y_pred)
+    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100
+
+
+def print_prediction_kpis(real, pred):
+    print("KPIs")
+    print(f"MAPE: {mean_absolute_percentage_error(real, pred):.3f} %")
+    print(f"R2: {r2_score(real, pred):.3f}")
+    print(f"MAE: {mean_absolute_error(real, pred):.3f}")
+    print(f"MSE: {mean_squared_error(real, pred):.3f}")
+    print(f"RMSE: {mean_squared_error(real, pred, squared=False):.3f}")
+
+
+def price_prediction_backtesting_color(val: int) -> str:
+    err_pct = 100 * (val[0] - val[1]) / val[1]
+    if val[0] > val[1]:
+        s_err_pct = f"       {Fore.GREEN} +{err_pct:.2f} %"
+    else:
+        s_err_pct = f"       {Fore.RED} {err_pct:.2f} %"
+    return f"{val[1]:.2f}    x    {Fore.YELLOW}{val[0]:.2f}{s_err_pct}{Style.RESET_ALL}"

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -42,7 +42,7 @@ def print_prediction_kpis(real, pred):
     print(f"RMSE: {mean_squared_error(real, pred, squared=False):.3f}")
 
 
-def price_prediction_backtesting_color(val: int) -> str:
+def price_prediction_backtesting_color(val: list) -> str:
     err_pct = 100 * (val[0] - val[1]) / val[1]
     if val[0] > val[1]:
         s_err_pct = f"       {Fore.GREEN} +{err_pct:.2f} %"

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 from colorama import Fore, Style
 from gamestonk_terminal import feature_flags as gtff
-import sklearn
 from sklearn.metrics import (
     mean_absolute_error,
     r2_score,

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -2,32 +2,13 @@ import numpy as np
 import pandas as pd
 from colorama import Fore, Style
 from gamestonk_terminal import feature_flags as gtff
+import sklearn
 from sklearn.metrics import (
     mean_absolute_error,
     mean_squared_error,
     r2_score,
     mean_squared_error,
 )
-
-
-def get_next_stock_market_days(last_stock_day, n_next_days) -> list:
-    n_days = 0
-    l_pred_days = list()
-    while n_days < n_next_days:
-
-        last_stock_day += timedelta(hours=24)
-
-        # Check if it is a weekend
-        if last_stock_day.date().weekday() > 4:
-            continue
-        # Check if it is a holiday
-        if last_stock_day.strftime("%Y-%m-%d") in holidaysUS():
-            continue
-        # Otherwise stock market is open
-        n_days += 1
-        l_pred_days.append(last_stock_day)
-
-    return l_pred_days
 
 
 def price_prediction_color(val: int, last_val: int) -> str:

--- a/gamestonk_terminal/prediction_techniques/pred_menu.py
+++ b/gamestonk_terminal/prediction_techniques/pred_menu.py
@@ -84,7 +84,7 @@ def pred_menu(df_stock, s_ticker, s_start, s_interval):
             as_input = input(f"{get_flair()} (pred)> ")
 
         # Images are non blocking - allows to close them if we type other command
-        plt.close()
+        plt.close("all")
 
         # Parse prediction techniques command of the list of possible commands
         try:

--- a/gamestonk_terminal/prediction_techniques/regression.py
+++ b/gamestonk_terminal/prediction_techniques/regression.py
@@ -106,12 +106,10 @@ def regression(l_args, s_ticker, df_stock, polynomial):
                 )
                 return
 
-            if (
-                ns_parser.s_end_date
-                < get_next_stock_market_days(
-                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
-                )[-1]
-            ):
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=df_stock.index[0],
+                n_next_days=ns_parser.n_inputs + ns_parser.n_days,
+            )[-1]:
                 print(
                     "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
                 )
@@ -260,7 +258,10 @@ def regression(l_args, s_ticker, df_stock, polynomial):
             )
             plt.title("BACKTESTING: Real data price versus Prediction")
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.ylabel("Share Price ($)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")
             plt.minorticks_on()
@@ -300,7 +301,10 @@ def regression(l_args, s_ticker, df_stock, polynomial):
                 c="red",
             )
             plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
-            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
             plt.xlabel("Time")
             plt.ylabel("Prediction Error (%)")
             plt.grid(b=True, which="major", color="#666666", linestyle="-")

--- a/gamestonk_terminal/prediction_techniques/regression.py
+++ b/gamestonk_terminal/prediction_techniques/regression.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import matplotlib.pyplot as plt
 import pandas as pd
 from pandas.plotting import register_matplotlib_converters
@@ -9,10 +10,18 @@ from sklearn import preprocessing
 
 from gamestonk_terminal.helper_funcs import (
     check_positive,
-    get_next_stock_market_days,
     parse_known_args_and_warn,
-    print_pretty_prediction,
+    valid_date,
+    patch_pandas_text_adjustment,
+    get_next_stock_market_days,
 )
+
+from gamestonk_terminal.prediction_techniques.pred_helper import (
+    print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
+)
+
 
 from gamestonk_terminal import feature_flags as gtff
 
@@ -63,6 +72,15 @@ def regression(l_args, s_ticker, df_stock, polynomial):
         default=1,
         help="number of jumps in training data.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     if polynomial == USER_INPUT:
         parser.add_argument(
@@ -80,6 +98,38 @@ def regression(l_args, s_ticker, df_stock, polynomial):
         if not ns_parser:
             return
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=ns_parser.n_inputs + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
+
         # Split training data
         stock_x, stock_y = splitTrain.split_train(
             df_stock["5. adjusted close"].values,
@@ -87,6 +137,10 @@ def regression(l_args, s_ticker, df_stock, polynomial):
             ns_parser.n_days,
             ns_parser.n_jumps,
         )
+
+        if not stock_x:
+            print("Given the model parameters more training data is needed.\n")
+            return
 
         # Machine Learning model
         if polynomial == LINEAR:
@@ -113,9 +167,15 @@ def regression(l_args, s_ticker, df_stock, polynomial):
         # Plotting
         plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=2)
-        plt.title(
-            f"Regression (polynomial {polynomial}) on {s_ticker} - {ns_parser.n_days} days prediction"
-        )
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: Regression (polynomial {polynomial}) on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(
+                f"Regression (polynomial {polynomial}) on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -140,13 +200,143 @@ def regression(l_args, s_ticker, df_stock, polynomial):
             df_stock.index[-1], ymin, ymax, linewidth=1, linestyle="--", color="k"
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks([df_stock.index[-1], df_pred.index[-1]+datetime.timedelta(days=1)], visible=True)
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:

--- a/gamestonk_terminal/prediction_techniques/sma.py
+++ b/gamestonk_terminal/prediction_techniques/sma.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -6,10 +7,18 @@ from pandas.plotting import register_matplotlib_converters
 
 from gamestonk_terminal.helper_funcs import (
     check_positive,
-    get_next_stock_market_days,
     parse_known_args_and_warn,
-    print_pretty_prediction,
+    valid_date,
+    patch_pandas_text_adjustment,
+    get_next_stock_market_days,
 )
+
+from gamestonk_terminal.prediction_techniques.pred_helper import (
+    print_pretty_prediction,
+    price_prediction_backtesting_color,
+    print_prediction_kpis,
+)
+
 
 from gamestonk_terminal import feature_flags as gtff
 
@@ -50,11 +59,53 @@ def simple_moving_average(l_args, s_ticker, df_stock):
         default=5,
         help="prediction days.",
     )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        type=valid_date,
+        dest="s_end_date",
+        default=None,
+        help="The end date (format YYYY-MM-DD) to select - Backtesting",
+    )
 
     try:
         ns_parser = parse_known_args_and_warn(parser, l_args)
         if not ns_parser:
             return
+
+        # BACKTESTING
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < df_stock.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if (
+                ns_parser.s_end_date
+                < get_next_stock_market_days(
+                    last_stock_day=df_stock.index[0], n_next_days=5 + ns_parser.n_days
+                )[-1]
+            ):
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+            future_index = get_next_stock_market_days(
+                last_stock_day=ns_parser.s_end_date, n_next_days=ns_parser.n_days
+            )
+
+            if future_index[-1] > datetime.datetime.now():
+                print(
+                    "Backtesting not allowed, since End Date + Prediction days is in the future\n"
+                )
+                return
+
+            df_future = df_stock[future_index[0] : future_index[-1]]
+            df_stock = df_stock[: ns_parser.s_end_date]
 
         # Prediction data
         l_predictions = list()
@@ -74,10 +125,17 @@ def simple_moving_average(l_args, s_ticker, df_stock):
         df_pred = pd.Series(l_predictions, index=l_pred_days, name="Price")
 
         # Plotting
+        plt.figure()
         plt.plot(df_stock.index, df_stock["5. adjusted close"], lw=2)
-        plt.title(
-            f"{ns_parser.n_length} Moving Average on {s_ticker} - {ns_parser.n_days} days prediction"
-        )
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.title(
+                f"BACKTESTING: {ns_parser.n_length} Moving Average on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
+        else:
+            plt.title(
+                f"{ns_parser.n_length} Moving Average on {s_ticker} - {ns_parser.n_days} days prediction"
+            )
         plt.xlim(
             df_stock.index[0], get_next_stock_market_days(df_pred.index[-1], 1)[-1]
         )
@@ -104,13 +162,149 @@ def simple_moving_average(l_args, s_ticker, df_stock):
             df_stock.index[-1], ymin, ymax, linewidth=1, linestyle="--", color="k"
         )
 
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=1,
+                c="tab:blue",
+                linestyle="--",
+            )
+
         if gtff.USE_ION:
             plt.ion()
 
         plt.show()
 
-        # Print prediction data
-        print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
+        # BACKTESTING
+        if ns_parser.s_end_date:
+            plt.figure()
+            plt.subplot(211)
+            plt.plot(
+                df_future.index,
+                df_future["5. adjusted close"],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.plot(df_pred.index, df_pred, lw=2, c="green")
+            plt.scatter(
+                df_future.index, df_future["5. adjusted close"], c="tab:blue", lw=3
+            )
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    df_stock["5. adjusted close"].values[-1],
+                    df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                c="tab:blue",
+                ls="--",
+            )
+            plt.scatter(df_pred.index, df_pred, c="green", lw=3)
+            plt.plot(
+                [df_stock.index[-1], df_pred.index[0]],
+                [df_stock["5. adjusted close"].values[-1], df_pred.values[0]],
+                lw=2,
+                c="green",
+                ls="--",
+            )
+            plt.title("BACKTESTING: Real data price versus Prediction")
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
+            plt.ylabel("Share Price ($)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+            plt.xticks([])
+
+            plt.subplot(212)
+            plt.axhline(y=0, color="k", linestyle="--", linewidth=2)
+            plt.plot(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                lw=2,
+                c="red",
+            )
+            plt.scatter(
+                df_future.index,
+                100
+                * (df_pred.values - df_future["5. adjusted close"].values)
+                / df_future["5. adjusted close"].values,
+                c="red",
+                lw=5,
+            )
+            plt.title("BACKTESTING: Error between Real data and Prediction [%]")
+            plt.plot(
+                [df_stock.index[-1], df_future.index[0]],
+                [
+                    0,
+                    100
+                    * (df_pred.values[0] - df_future["5. adjusted close"].values[0])
+                    / df_future["5. adjusted close"].values[0],
+                ],
+                lw=2,
+                ls="--",
+                c="red",
+            )
+            plt.xlim(df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1))
+            plt.xticks(
+                [df_stock.index[-1], df_pred.index[-1] + datetime.timedelta(days=1)],
+                visible=True,
+            )
+            plt.xlabel("Time")
+            plt.ylabel("Prediction Error (%)")
+            plt.grid(b=True, which="major", color="#666666", linestyle="-")
+            plt.minorticks_on()
+            plt.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
+            plt.legend(["Real data", "Prediction data"])
+
+            if gtff.USE_ION:
+                plt.ion()
+
+            plt.show()
+
+            # Refactor prediction dataframe for backtesting print
+            df_pred.name = "Prediction"
+            df_pred = df_pred.to_frame()
+            df_pred["Real"] = df_future["5. adjusted close"]
+
+            if gtff.USE_COLOR:
+
+                patch_pandas_text_adjustment()
+
+                print("Time         Real [$]  x  Prediction [$]")
+                print(
+                    df_pred.apply(
+                        price_prediction_backtesting_color, axis=1
+                    ).to_string()
+                )
+            else:
+                print(df_pred[["Real", "Prediction"]].round(2).to_string())
+
+            print("")
+            print_prediction_kpis(df_pred["Real"].values, df_pred["Prediction"].values)
+
+        else:
+            # Print prediction data
+            print_pretty_prediction(df_pred, df_stock["5. adjusted close"].values[-1])
         print("")
 
     except Exception as e:


### PR DESCRIPTION
The code is a bit of a mess, but it's working :)

The user enters in "backtesting mode" when it sets the flag "-e" for end_date when in prediction.

The different features are:
- Normal plot shows what is the actual data vs the predicted
- A new plot that shows in better detail actual data vs predicted, and error in percentage
- Prints the actual data vs predicted vs error percentage
- Prints some KPIs, such as RMSE, MAE, MAPE


<img width="1210" alt="Captura de ecrã 2021-03-13, às 22 54 18" src="https://user-images.githubusercontent.com/25267873/111052068-b17d6500-844f-11eb-9e70-b61dbc255ac3.png">
