### PR TITLE
Add losers command on discovery menu

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@
 * [Prediction Techniques](#Prediction-Techniques)
 * [Reports](#Reports)
 * [Comparison Analysis](#Comparison-Analysis)
+* [Exploratory Data Analysis](#Exploratory-Data-Analysis)
 * [Portfolio Analysis](#Portfolio-Analysis)
 * [Credit Analysis](#Credit-Analysis)
 * [Cryptocurrencies](#Cryptocurrencies)
@@ -25,7 +26,7 @@
 
 ### Short term
 
-- [ ] Top Losers (@didier)
+- [x] Top Losers (@didier) - [PR #171](https://github.com/DidierRLopes/GamestonkTerminal/pull/171)
 - [x] ARK orders (@aia) - [PR #140](https://github.com/DidierRLopes/GamestonkTerminal/pull/140)
 
 ### Long term
@@ -60,7 +61,7 @@
 
 ### Short term
 
-- [ ] Rearrange FA menu to have AV and FMP as submenus (@didier)
+- [x] Rearrange FA menu to have AV and FMP as submenus (@didier) - [PR #166](https://github.com/DidierRLopes/GamestonkTerminal/pull/166)
 
 ### Long term
 
@@ -105,17 +106,27 @@
 
 ---
 
-## ComparisonAnalysis
+## Comparison Analysis
 
 ### Short term
 
-* [X] Add multi-ticker historical data comparison (@didier) - [PR #141](https://github.com/DidierRLopes/GamestonkTerminal/pull/141)
+* [x] Add multi-ticker historical data comparison (@didier) - [PR #141](https://github.com/DidierRLopes/GamestonkTerminal/pull/141)
 * [ ] Add multi-ticker financials comparison (@didier)
 
 ### Long term
 
 ---
 
+## Exploratory Data Analysis
+
+### Short term
+
+* [ ] Statistical techniques applied to a stock share price (e.g. decompose seasonality, trend, level, auto-correlation, cusum, ...) (@didier)
+* [ ] Hypothesis tests (e.g. Kurtosis, Jarques-Bera, ARCH, ADF, ...) (@didier)
+
+### Long term
+
+---
 
 ## Portfolio Analysis
 
@@ -164,7 +175,7 @@
 ### Short term
 
 - [x] Add terminal flair (@aia) - [PR #131](https://github.com/DidierRLopes/GamestonkTerminal/pull/131)
-- [ ] Prompt-toolkit (@ricleal) - [PR #142](https://github.com/DidierRLopes/GamestonkTerminal/)
+- [x] Prompt-toolkit (@ricleal) - [PR #142](https://github.com/DidierRLopes/GamestonkTerminal/pull/142)
 
 ### Long term
 

--- a/gamestonk_terminal/discovery/README.md
+++ b/gamestonk_terminal/discovery/README.md
@@ -8,6 +8,8 @@ This menu aims to discover new stocks, and the usage of the following commands a
   * show sectors performance [Alpha Vantage]
 * [gainers](#gainers)
   * show latest top gainers [Yahoo Finance]
+* [losers](#losers)
+  * show latest top losers [Yahoo Finance]
 * [orders](#orders)
   * orders by Fidelity Customers [Fidelity]
 * [ark_orders](#ark_orders)
@@ -59,6 +61,18 @@ Print up to 25 top ticker gainers in terminal. [Source: Yahoo Finance]
 * -n : Number of the top gainers stocks to retrieve. Default 5.
 
 <img width="935" alt="Captura de ecrã 2021-02-20, às 11 46 09" src="https://user-images.githubusercontent.com/25267873/108594319-46b99c00-7371-11eb-877e-ef75d3ba472b.png">
+
+## losers <a name="losers"></a>
+
+```shell
+usage: losers [-n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}]
+```
+
+Print up to 25 top ticker losers in terminal. [Source: Yahoo Finance]
+
+* -n : Number of the top losers stocks to retrieve. Default 5.
+
+<img width="993" alt="Captura de ecrã 2021-03-14, às 20 23 21" src="https://user-images.githubusercontent.com/25267873/111083099-a421b280-8503-11eb-9bb0-c728ce1e313f.png">
 
 ## orders <a name="orders"></a>
 

--- a/gamestonk_terminal/discovery/ark_api.py
+++ b/gamestonk_terminal/discovery/ark_api.py
@@ -41,6 +41,10 @@ def get_ark_orders() -> DataFrame:
     parsed_json = json.loads(parsed_script.string)
 
     df_orders = pd.json_normalize(parsed_json["props"]["pageProps"]["arkTrades"])
+
+    if df_orders.empty:
+        return pd.DataFrame()
+
     df_orders.drop(
         [
             "everything",
@@ -115,6 +119,10 @@ def ark_orders(l_args):
         return
 
     df_orders = get_ark_orders()
+
+    if df_orders.empty:
+        print("The ARK orders aren't anavilable at the moment.\n")
+        return
 
     pd.set_option("mode.chained_assignment", None)
     df_orders = add_order_total(df_orders.head(ns_parser.n_num))

--- a/gamestonk_terminal/discovery/disc_menu.py
+++ b/gamestonk_terminal/discovery/disc_menu.py
@@ -29,6 +29,7 @@ def print_discovery():
     print("   map           S&P500 index stocks map [Finviz]")
     print("   sectors       show sectors performance [Alpha Vantage]")
     print("   gainers       show latest top gainers [Yahoo Finance]")
+    print("   losers        show latest top losers [Yahoo Finance]")
     print("   orders        orders by Fidelity Customers [Fidelity]")
     print("   ark_orders    orders by ARK Investment Management LLC")
     print("   up_earnings   upcoming earnings release dates [Seeking Alpha]")
@@ -56,6 +57,7 @@ def disc_menu():
         "map",
         "sectors",
         "gainers",
+        "losers",
         "spacs",
         "orders",
         "ark_orders",
@@ -110,6 +112,9 @@ def disc_menu():
 
         elif ns_known_args.cmd == "gainers":
             yahoo_finance_api.gainers(l_args)
+
+        elif ns_known_args.cmd == "losers":
+            yahoo_finance_api.losers(l_args)
 
         elif ns_known_args.cmd == "spachero":
             spachero_api.spachero(l_args)

--- a/gamestonk_terminal/discovery/yahoo_finance_api.py
+++ b/gamestonk_terminal/discovery/yahoo_finance_api.py
@@ -7,7 +7,7 @@ def gainers(l_args):
     parser = argparse.ArgumentParser(
         add_help=False,
         prog="gainers",
-        description="Print up to 25 top ticker gainers in terminal. [Source: Yahoo Finance]",
+        description="Print up to 25 top ticker gainers. [Source: Yahoo Finance]",
     )
 
     parser.add_argument(
@@ -29,4 +29,33 @@ def gainers(l_args):
         "https://finance.yahoo.com/screener/predefined/day_gainers"
     )[0]
     print(df_gainers.head(ns_parser.n_gainers).to_string(index=False))
+    print("")
+
+
+def losers(l_args):
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="losers",
+        description="Print up to 25 top ticker losers. [Source: Yahoo Finance]",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--num",
+        action="store",
+        dest="n_losers",
+        type=int,
+        default=5,
+        choices=range(1, 25),
+        help="Number of the top losers stocks to retrieve.",
+    )
+
+    ns_parser = parse_known_args_and_warn(parser, l_args)
+    if not ns_parser:
+        return
+
+    df_losers = pd.read_html(
+        "https://finance.yahoo.com/screener/predefined/day_losers"
+    )[0]
+    print(df_losers.head(ns_parser.n_losers).to_string(index=False))
     print("")


### PR DESCRIPTION
Top losers: 
<img width="993" alt="Captura de ecrã 2021-03-14, às 20 23 21" src="https://user-images.githubusercontent.com/25267873/111083463-a84ecf80-8505-11eb-99bf-5ae4c5db67aa.png">

@aia ark_order was failing due to no data in https://cathiesark.com/ark-funds-combined/complete-holdings when "combined" filter is selected. Not sure why, since ARKK, ARKW, ARKF, ... are not empty.