### PR TITLE
Non-breaking import readline

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -2,6 +2,11 @@
 
 import argparse
 
+try:
+    import readline  # noqa: F401
+except ImportError:
+    pass
+
 from datetime import datetime, timedelta
 import pandas as pd
 from alpha_vantage.timeseries import TimeSeries


### PR DESCRIPTION
Importing readline will improve user experience by letting users do a few things:
- easily access their command history from the current session using up/down arrows
- reverse history search with crtl+r
- use emacs keybindings (ctrl+a, etc)

I'll add this to the PR description, thanks!

Attempted in #77 and #80. However there were issues due to the lack of availability of readline in windows environments.

If merged this will add readline support _where available_, improving the UX on those platforms. There is also room to later import a solution available on windows in the `except` block.