### PR TITLE
Enable prompt toolkit by default

### DIFF
--- a/gamestonk_terminal/feature_flags.py
+++ b/gamestonk_terminal/feature_flags.py
@@ -3,7 +3,7 @@ import os
 USE_COLOR = os.getenv("GTFF_USE_COLOR") or True
 USE_FLAIR = os.getenv("GTFF_USE_FLAIR") or "stars"
 USE_ION = os.getenv("GTFF_USE_ION") or True
-USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT") or False
+USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT") or True
 
 # Enable Prediction features
 ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT") or False


### PR DESCRIPTION
Enable prompt toolkit by default. This feature was added in #142 and greatly improves the UX of the terminal.

If there are any downsides to enabling this lets discuss them here