### PR TITLE
Registers pyplot.draw as inputhook for prompt_toolkit

### DIFF
--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -1,7 +1,7 @@
 name: Mac OS X Full Clean Build with ML
 env:
-  GTFF_USE_PROMPT_TOOLKIT: False
-  GTFF_USE_ION: False
+  GTFF_USE_PROMPT_TOOLKIT:
+  GTFF_USE_ION:
 on:
   push:
     branches:

--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -1,7 +1,7 @@
 name: Mac OS X Full Clean Build with ML
 env:
-  GTFF_USE_PROMPT_TOOLKIT: false
-  GTFF_USE_ION: false
+  GTFF_USE_PROMPT_TOOLKIT: False
+  GTFF_USE_ION: False
 on:
   push:
     branches:

--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -1,7 +1,7 @@
 name: Mac OS X Full Clean Build with ML
 env:
-  GTFF_USE_PROMPT_TOOLKIT:
-  GTFF_USE_ION:
+  GTFF_USE_PROMPT_TOOLKIT: false
+  GTFF_USE_ION: false
 on:
   push:
     branches:

--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -1,4 +1,7 @@
 name: Mac OS X Full Clean Build with ML
+env:
+  GTFF_USE_PROMPT_TOOLKIT: false
+  GTFF_USE_ION: false
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Tests
+env:
+    GTFF_USE_PROMPT_TOOLKIT: false
+    GTFF_USE_ION: false
 on: [pull_request, push]
 jobs:
   linting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 env:
-    GTFF_USE_PROMPT_TOOLKIT:
-    GTFF_USE_ION:
+    GTFF_USE_PROMPT_TOOLKIT: false
+    GTFF_USE_ION: false
 on: [pull_request, push]
 jobs:
   linting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 env:
-    GTFF_USE_PROMPT_TOOLKIT: False
-    GTFF_USE_ION: False
+    GTFF_USE_PROMPT_TOOLKIT:
+    GTFF_USE_ION:
 on: [pull_request, push]
 jobs:
   linting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 env:
-    GTFF_USE_PROMPT_TOOLKIT: false
-    GTFF_USE_ION: false
+    GTFF_USE_PROMPT_TOOLKIT: False
+    GTFF_USE_ION: False
 on: [pull_request, push]
 jobs:
   linting:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,7 @@
 name: Windows 10 Full Clean Build with ML
+env:
+  GTFF_USE_PROMPT_TOOLKIT: false
+  GTFF_USE_ION: false
 on:
   push:
     branches:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,7 @@
 name: Windows 10 Full Clean Build with ML
 env:
-  GTFF_USE_PROMPT_TOOLKIT:
-  GTFF_USE_ION:
+  GTFF_USE_PROMPT_TOOLKIT: false
+  GTFF_USE_ION: false
 on:
   push:
     branches:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,7 @@
 name: Windows 10 Full Clean Build with ML
 env:
-  GTFF_USE_PROMPT_TOOLKIT: False
-  GTFF_USE_ION: False
+  GTFF_USE_PROMPT_TOOLKIT:
+  GTFF_USE_ION:
 on:
   push:
     branches:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,7 @@
 name: Windows 10 Full Clean Build with ML
 env:
-  GTFF_USE_PROMPT_TOOLKIT: false
-  GTFF_USE_ION: false
+  GTFF_USE_PROMPT_TOOLKIT: False
+  GTFF_USE_ION: False
 on:
   push:
     branches:

--- a/gamestonk_terminal/feature_flags.py
+++ b/gamestonk_terminal/feature_flags.py
@@ -1,23 +1,13 @@
+from distutils.util import strtobool
 import os
 
-# env vars are strings not booleans
-# check for "false" or "0"
-# any other value is true (including empty string)
-
-USE_COLOR = os.getenv("GTFF_USE_COLOR", "true").lower() not in ["false", "0"]
-USE_FLAIR = os.getenv("GTFF_USE_FLAIR", "stars")
-USE_ION = os.getenv("GTFF_USE_ION", "true").lower() not in ["false", "0"]
-USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT", "false").lower() not in [
-    "false",
-    "0",
-]
-
+USE_COLOR = strtobool(os.getenv("GTFF_USE_COLOR", "True"))
+USE_FLAIR = os.getenv("GTFF_USE_FLAIR") or "stars"
+USE_ION = strtobool(os.getenv("GTFF_USE_ION", "True"))
+USE_PROMPT_TOOLKIT = strtobool(os.getenv("GTFF_USE_PROMPT_TOOLKIT", "False"))
 
 # Enable Prediction features
-ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT", "false").lower() not in ["false", "0"]
+ENABLE_PREDICT = strtobool(os.getenv("GTFF_ENABLE_PREDICT", "False"))
 
 # Enable plot autoscaling
-USE_PLOT_AUTOSCALING = os.getenv("GTFF_USE_PLOT_AUTOSCALING", "false").lower() not in [
-    "false",
-    "0",
-]
+USE_PLOT_AUTOSCALING = strtobool(os.getenv("GTFF_USE_PLOT_AUTOSCALING", "False"))

--- a/gamestonk_terminal/feature_flags.py
+++ b/gamestonk_terminal/feature_flags.py
@@ -1,12 +1,12 @@
 import os
 
-USE_COLOR = os.getenv("GTFF_USE_COLOR") or True
+USE_COLOR = os.getenv("GTFF_USE_COLOR").lower() not in ['false', '0'] or True
 USE_FLAIR = os.getenv("GTFF_USE_FLAIR") or "stars"
-USE_ION = os.getenv("GTFF_USE_ION") or True
-USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT") or False
+USE_ION = os.getenv("GTFF_USE_ION").lower() not in ['false', '0'] or True
+USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT").lower() not in ['false', '0'] or False
 
 # Enable Prediction features
-ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT") or False
+ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT").lower() not in ['false', '0'] or False
 
 # Enable plot autoscaling
-USE_PLOT_AUTOSCALING = os.getenv("GTFF_USE_PLOT_AUTOSCALING") or False
+USE_PLOT_AUTOSCALING = os.getenv("GTFF_USE_PLOT_AUTOSCALING").lower() not in ['false', '0'] or False

--- a/gamestonk_terminal/feature_flags.py
+++ b/gamestonk_terminal/feature_flags.py
@@ -1,12 +1,16 @@
 import os
 
-USE_COLOR = os.getenv("GTFF_USE_COLOR").lower() not in ['false', '0'] or True
+USE_COLOR = os.getenv("GTFF_USE_COLOR").lower() not in ["false", "0"] or True
 USE_FLAIR = os.getenv("GTFF_USE_FLAIR") or "stars"
-USE_ION = os.getenv("GTFF_USE_ION").lower() not in ['false', '0'] or True
-USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT").lower() not in ['false', '0'] or False
+USE_ION = os.getenv("GTFF_USE_ION").lower() not in ["false", "0"] or True
+USE_PROMPT_TOOLKIT = (
+    os.getenv("GTFF_USE_PROMPT_TOOLKIT").lower() not in ["false", "0"] or False
+)
 
 # Enable Prediction features
-ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT").lower() not in ['false', '0'] or False
+ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT").lower() not in ["false", "0"] or False
 
 # Enable plot autoscaling
-USE_PLOT_AUTOSCALING = os.getenv("GTFF_USE_PLOT_AUTOSCALING").lower() not in ['false', '0'] or False
+USE_PLOT_AUTOSCALING = (
+    os.getenv("GTFF_USE_PLOT_AUTOSCALING").lower() not in ["false", "0"] or False
+)

--- a/gamestonk_terminal/feature_flags.py
+++ b/gamestonk_terminal/feature_flags.py
@@ -1,16 +1,23 @@
 import os
 
-USE_COLOR = os.getenv("GTFF_USE_COLOR").lower() not in ["false", "0"] or True
-USE_FLAIR = os.getenv("GTFF_USE_FLAIR") or "stars"
-USE_ION = os.getenv("GTFF_USE_ION").lower() not in ["false", "0"] or True
-USE_PROMPT_TOOLKIT = (
-    os.getenv("GTFF_USE_PROMPT_TOOLKIT").lower() not in ["false", "0"] or False
-)
+# env vars are strings not booleans
+# check for "false" or "0"
+# any other value is true (including empty string)
+
+USE_COLOR = os.getenv("GTFF_USE_COLOR", "true").lower() not in ["false", "0"]
+USE_FLAIR = os.getenv("GTFF_USE_FLAIR", "stars")
+USE_ION = os.getenv("GTFF_USE_ION", "true").lower() not in ["false", "0"]
+USE_PROMPT_TOOLKIT = os.getenv("GTFF_USE_PROMPT_TOOLKIT", "false").lower() not in [
+    "false",
+    "0",
+]
+
 
 # Enable Prediction features
-ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT").lower() not in ["false", "0"] or False
+ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT", "false").lower() not in ["false", "0"]
 
 # Enable plot autoscaling
-USE_PLOT_AUTOSCALING = (
-    os.getenv("GTFF_USE_PLOT_AUTOSCALING").lower() not in ["false", "0"] or False
-)
+USE_PLOT_AUTOSCALING = os.getenv("GTFF_USE_PLOT_AUTOSCALING", "false").lower() not in [
+    "false",
+    "0",
+]

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -6,10 +6,12 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.eventloop.inputhook import set_eventloop_with_inputhook
 from prompt_toolkit.history import FileHistory
 
+
 def inputhook(inputhook_context):
     while not inputhook_context.input_is_ready():
         pyplot.pause(0.1)
     return False
+
 
 history_file = os.path.join(os.path.expanduser("~"), ".gamestonk_terminal.his")
 

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -19,5 +19,7 @@ try:
     session = PromptSession(history=FileHistory(history_file))
     set_eventloop_with_inputhook(inputhook)
 except Exception as e:  # noqa: F841
-    print("WARNING: Prompt toolkit is turned on but did not initialize succesfully. Falling back to input()...")
+    print(
+        "WARNING: Prompt toolkit is turned on but did not initialize succesfully. Falling back to input()..."
+    )
     session = None

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -8,6 +8,6 @@ from prompt_toolkit.history import FileHistory
 history_file = os.path.join(os.path.expanduser("~"), ".gamestonk_terminal.his")
 
 try:
-    session = PromptSession(history=FileHistory(history_file), inputhook=pyplot.draw())
+    session = PromptSession(history=FileHistory(history_file), inputhook=pyplot.draw)
 except Exception as e:  # noqa: F841
     session = None

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -20,6 +20,6 @@ try:
     set_eventloop_with_inputhook(inputhook)
 except Exception as e:  # noqa: F841
     print(
-        "WARNING: Prompt toolkit is turned on but did not initialize succesfully. Falling back to input()..."
+        "WARNING: Prompt toolkit is turned on but did not initialize successfully. Falling back to input()..."
     )
     session = None

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -1,11 +1,13 @@
 import os
 
+from matplotlib import pyplot
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import FileHistory
 
 history_file = os.path.join(os.path.expanduser("~"), ".gamestonk_terminal.his")
 
 try:
-    session = PromptSession(history=FileHistory(history_file))
+    session = PromptSession(history=FileHistory(history_file), inputhook=pyplot.draw())
 except Exception as e:  # noqa: F841
     session = None

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -3,11 +3,18 @@ import os
 from matplotlib import pyplot
 
 from prompt_toolkit import PromptSession
+from prompt_toolkit.eventloop.inputhook import set_eventloop_with_inputhook
 from prompt_toolkit.history import FileHistory
+
+def inputhook(inputhook_context):
+    while not inputhook_context.input_is_ready():
+        pyplot.pause(0.1)
+    return False
 
 history_file = os.path.join(os.path.expanduser("~"), ".gamestonk_terminal.his")
 
 try:
-    session = PromptSession(history=FileHistory(history_file), inputhook=pyplot.draw)
+    session = PromptSession(history=FileHistory(history_file))
+    set_eventloop_with_inputhook(inputhook)
 except Exception as e:  # noqa: F841
-    session = None
+    raise e

--- a/gamestonk_terminal/menu.py
+++ b/gamestonk_terminal/menu.py
@@ -19,4 +19,5 @@ try:
     session = PromptSession(history=FileHistory(history_file))
     set_eventloop_with_inputhook(inputhook)
 except Exception as e:  # noqa: F841
-    raise e
+    print("WARNING: Prompt toolkit is turned on but did not initialize succesfully. Falling back to input()...")
+    session = None


### PR DESCRIPTION
This patch resolves the issue that was causing interactive plots to hang when prompt_toolkit is used by registering [matplotlib.pyplot.draw()](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.draw.html) as the input hook for the prompt session, which means the graphs will get updated whenever the prompt is blocked waiting for input. It will still be necessary to use the feature flag to disable prompt toolkit for batch scripts (since it expects a tty and doesn't work if stdin is just a file) but for the interactive use case this should enable both prompt_toolkit and plt.ion to coexist peacefully so it can work as the default. I checked with basic (view) plots and it appears to work well.

Potentially unblocks #177.