### PR TITLE
Adds snapshot command to save the current graph to an image file

### DIFF
--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -490,7 +490,7 @@ def snapshot(l_args, s_ticker):
         print(f"Supported image formats: {supported_image_formats}")
         return
     if not s_ticker:
-        print(f"You must LOAD a ticker symbol and plot a graph first")
+        print("You must LOAD a ticker symbol and plot a graph first")
         return
     plt.savefig(
         f"{ns_parser.fname}.{ns_parser.image_format}", format=ns_parser.image_format

--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -492,5 +492,7 @@ def snapshot(l_args, s_ticker):
     if not s_ticker:
         print(f"You must LOAD a ticker symbol and plot a graph first")
         return
-    plt.savefig(f"{ns_parser.fname}.{ns_parser.image_format}", format=ns_parser.image_format)
+    plt.savefig(
+        f"{ns_parser.fname}.{ns_parser.image_format}", format=ns_parser.image_format
+    )
     print(f"Saved {ns_parser.fname}.{ns_parser.image_format}")

--- a/terminal.py
+++ b/terminal.py
@@ -16,7 +16,7 @@ from gamestonk_terminal.discovery import disc_menu as dm
 from gamestonk_terminal.due_diligence import dd_menu as ddm
 from gamestonk_terminal.fundamental_analysis import fa_menu as fam
 from gamestonk_terminal.helper_funcs import b_is_stock_market_open, get_flair
-from gamestonk_terminal.main_helper import clear, export, load, print_help, view, candle
+from gamestonk_terminal.main_helper import clear, export, load, print_help, view, candle, snapshot
 from gamestonk_terminal.menu import session
 from gamestonk_terminal.papermill import papermill_controller as mill
 from gamestonk_terminal.behavioural_analysis import ba_controller
@@ -75,6 +75,7 @@ def main():
         "ca",
         "op",
         "fred",
+        "snapshot",
     ]
     menu_parser.add_argument("opt", choices=choices)
     completer = NestedCompleter.from_nested_dict({c: None for c in choices})
@@ -156,6 +157,10 @@ def main():
 
         elif ns_known_args.opt == "export":
             export(l_args, df_stock)
+            main_cmd = True
+
+        elif ns_known_args.opt == "snapshot":
+            snapshot(l_args, s_ticker)
             main_cmd = True
 
         elif ns_known_args.opt == "disc":

--- a/terminal.py
+++ b/terminal.py
@@ -16,7 +16,15 @@ from gamestonk_terminal.discovery import disc_menu as dm
 from gamestonk_terminal.due_diligence import dd_menu as ddm
 from gamestonk_terminal.fundamental_analysis import fa_menu as fam
 from gamestonk_terminal.helper_funcs import b_is_stock_market_open, get_flair
-from gamestonk_terminal.main_helper import clear, export, load, print_help, view, candle, snapshot
+from gamestonk_terminal.main_helper import (
+    clear,
+    export,
+    load,
+    print_help,
+    view,
+    candle,
+    snapshot,
+)
 from gamestonk_terminal.menu import session
 from gamestonk_terminal.papermill import papermill_controller as mill
 from gamestonk_terminal.behavioural_analysis import ba_controller


### PR DESCRIPTION
This patch implements the `snapshot` command to save the current figure to an image file. Supports .svg, .png, and .pdf formats. This may seem redundant in an interactive setup with a display where the plot window itself provides save functionality, but for users who want to run in a headless environment that doesn't have access to a GUI display this provides a way to get plots out. Particularly helpful in the context of a container environment where a host X display may not be available or wanted, although the full headless batch dream will also require some logic around `plt.show()` in headless environments.