### PR TITLE
Add US Dollar strength against the Euro and Yen to the econ data

### DIFF
--- a/notebooks/templates/econ_data.ipynb
+++ b/notebooks/templates/econ_data.ipynb
@@ -214,6 +214,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "illusory-reflection",
+   "metadata": {},
+   "source": [
+    "## Euro vs US Dollar - 2 year trend with 20, 50 and 200 day SMA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "astonishing-star",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edh.draw_graph(\"FXE\", cache_dir, line_type=\"line\", draw_mas=(20,50,200), draw_volume=True, time_delta=720, low_trend=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "reflective-panda",
+   "metadata": {},
+   "source": [
+    "## Yen vs US Dollar - 2 year trend with 20, 50 and 200 day SMA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "starry-night",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edh.draw_graph(\"FXY\", cache_dir, line_type=\"line\", draw_mas=(20,50,200), draw_volume=True, time_delta=720, low_trend=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "faced-canon",
    "metadata": {},
    "source": [


### PR DESCRIPTION
The strength of the US Dollar is another good indicator of the general economy. This PR adds US dollar vs Euro and Yen to the econ data in papermill.