### PR TITLE
Enable median/quantiles around loop of Neural Networks predictions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,7 +96,7 @@
 
 - [x] Add several exponential smoothing techniques (@didier) - [PR #132](https://github.com/DidierRLopes/GamestonkTerminal/pull/132)
 - [x] Allow backtesting (@didier) - [PR #169](https://github.com/DidierRLopes/GamestonkTerminal/pull/169)
-- [ ] Add averaging around multiple predictions - [IS #240](https://github.com/DidierRLopes/GamestonkTerminal/issues/240)
+- [x] Add averaging around multiple predictions (@didier) - [PR #252](https://github.com/DidierRLopes/GamestonkTerminal/pull/252)
 
 ### Long term
 

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -36,7 +36,7 @@ def valid_date(s: str) -> datetime:
     try:
         return datetime.strptime(s, "%Y-%m-%d")
     except ValueError as value_error:
-        raise argparse.ArgumentTypeError("Not a valid date: {s}") from value_error
+        raise argparse.ArgumentTypeError(f"Not a valid date: {s}") from value_error
 
 
 def plot_view_stock(df, symbol):

--- a/gamestonk_terminal/prediction_techniques/README.md
+++ b/gamestonk_terminal/prediction_techniques/README.md
@@ -24,6 +24,7 @@ This menu aims to predict the share price of a pre-loaded stock, and the usage o
     - MultiLayer Perceptron
   * [rnn](#rnn)
     - Recurrent Neural Network
+    - Contains a [looping example](#looping)
   * [lstm](#lstm)
     - Long-Short Term Memory
     - Contains a [backtesting example](#backtesting)
@@ -168,6 +169,7 @@ MulitLayer Perceptron:
   * --xla_gpu: if present, will enable XLA for GPU (overrides environment variables during run).
   * --force_allow_gpu_growth: if true, will force TensorFlow to allow GPU memory usage to grow as needed. Otherwise will allocate 100% of available GPU memory when CUDA is set up. Default true.
   * --batch_size: batch size for model training, should not be used unless advanced user. Default None.
+  * --loops: number of loops to iterate and train models. Default 1.
 
 Due to the complexity of defining a model through command line, one can define it in: [config_neural_network_models.txt](/config_neural_network_models.py)
 ```
@@ -204,6 +206,7 @@ Recurrent Neural Network:
   * --xla_gpu: if present, will enable XLA for GPU (overrides environment variables during run).
   * --force_allow_gpu_growth: if true, will force TensorFlow to allow GPU memory usage to grow as needed. Otherwise will allocate 100% of available GPU memory when CUDA is set up. Default true.
   * --batch_size: batch size for model training, should not be used unless advanced user. Default None.
+  * --loops: number of loops to iterate and train models. Default 1.
 
 Due to the complexity of defining a model through command line, one can define it in: [config_neural_network_models.txt](/config_neural_network_models.py)
 ```
@@ -221,6 +224,13 @@ Recurrent_Neural_Network \
 ```
 
 ![rnn](https://user-images.githubusercontent.com/25267873/108604940-d0d12700-73a8-11eb-837e-a5aa128942d9.png)
+
+### Looping Example <a name="looping"></a>
+
+![loops](https://user-images.githubusercontent.com/25267873/111932423-479b3600-8ab5-11eb-9d0b-7210d5f02e83.png)
+
+<img width="1006" alt="Captura de ecrã 2021-03-22, às 02 14 38" src="https://user-images.githubusercontent.com/25267873/111932420-436f1880-8ab5-11eb-831c-ebb88f1c5473.png">
+
 
 ## lstm <a name="lstm"></a>
 ```
@@ -240,6 +250,7 @@ Long-Short Term Memory:
   * --xla_gpu: if present, will enable XLA for GPU (overrides environment variables during run).
   * --force_allow_gpu_growth: if true, will force TensorFlow to allow GPU memory usage to grow as needed. Otherwise will allocate 100% of available GPU memory when CUDA is set up. Default true.
   * --batch_size: batch size for model training, should not be used unless advanced user. Default None.
+  * --loops: number of loops to iterate and train models. Default 1.
 
 Due to the complexity of defining a model through command line, one can define it in: [config_neural_network_models.py](/config_neural_network_models.py)
 ```

--- a/gamestonk_terminal/prediction_techniques/README.md
+++ b/gamestonk_terminal/prediction_techniques/README.md
@@ -153,8 +153,8 @@ Facebook's Prophet:
 
 ## mlp <a name="mlp"></a>
 ```
-usage: mlp [-d N_DAYS] [-i N_INPUTS] [-j N_JUMPS] [-e N_EPOCHS] [-p {normalization,standardization,none}]
-[-o {adam,adagrad,adadelta,adamax,ftrl,nadam,optimizer,rmsprop,sgd}] [-l {mae,mape,mse,msle}]
+usage: mlp [-d N_DAYS] [-i N_INPUTS] [-j N_JUMPS] [--epochs N_EPOCHS] [-p {normalization,standardization,none}]
+[-o {adam,adagrad,adadelta,adamax,ftrl,nadam,optimizer,rmsprop,sgd}] [-l {mae,mape,mse,msle}] [-e S_END_DATE] [--loops N_LOOPS]
 ```
 MulitLayer Perceptron:
   * -d : prediciton days. Default 5.
@@ -190,8 +190,8 @@ MultiLayer_Perceptron \
 
 ## rnn <a name="rnn"></a>
 ```
-usage: rnn [-d N_DAYS] [-i N_INPUTS] [-j N_JUMPS] [-e N_EPOCHS] [-p {normalization,standardization,none}]
-[-o {adam,adagrad,adadelta,adamax,ftrl,nadam,optimizer,rmsprop,sgd}] [-l {mae,mape,mse,msle}]
+usage: rnn [-d N_DAYS] [-i N_INPUTS] [-j N_JUMPS] [--epochs N_EPOCHS] [-p {normalization,standardization,none}]
+[-o {adam,adagrad,adadelta,adamax,ftrl,nadam,optimizer,rmsprop,sgd}] [-l {mae,mape,mse,msle}] [-e S_END_DATE] [--loops N_LOOPS]
 ```
 Recurrent Neural Network:
   * -d : prediciton days. Default 5.
@@ -234,8 +234,8 @@ Recurrent_Neural_Network \
 
 ## lstm <a name="lstm"></a>
 ```
-usage: lstm [-d N_DAYS] [-i N_INPUTS] [-j N_JUMPS] [-e N_EPOCHS] [-p {normalization,standardization,none}]
-[-o {adam,adagrad,adadelta,adamax,ftrl,nadam,optimizer,rmsprop,sgd}] [-l {mae,mape,mse,msle}]
+usage: lstm [-d N_DAYS] [-i N_INPUTS] [-j N_JUMPS] [--epochs N_EPOCHS] [-p {normalization,standardization,none}]
+[-o {adam,adagrad,adadelta,adamax,ftrl,nadam,optimizer,rmsprop,sgd}] [-l {mae,mape,mse,msle}] [-e S_END_DATE] [--loops N_LOOPS]
 ```
 Long-Short Term Memory:
   * -d : prediciton days. Default 5.

--- a/gamestonk_terminal/prediction_techniques/neural_networks.py
+++ b/gamestonk_terminal/prediction_techniques/neural_networks.py
@@ -374,9 +374,8 @@ def _plot_and_print_results(
             )
     else:
         if ns_parser.s_end_date:
-            plt.title(
-                f"{ns_parser.n_loops} loops - BACKTESTING: {model_name} on {s_ticker} - {ns_parser.n_days} days prediction"
-            )
+            s_title = f"{ns_parser.n_loops} loops - BACKTESTING: {model_name} on {s_ticker} - {ns_parser.n_days} days prediction"
+            plt.title(s_title)
         else:
             plt.title(
                 f"{ns_parser.n_loops} loops - {model_name} on {s_ticker} - {ns_parser.n_days} days prediction"

--- a/gamestonk_terminal/prediction_techniques/neural_networks.py
+++ b/gamestonk_terminal/prediction_techniques/neural_networks.py
@@ -374,8 +374,10 @@ def _plot_and_print_results(
             )
     else:
         if ns_parser.s_end_date:
-            s_title = f"{ns_parser.n_loops} loops - BACKTESTING: {model_name} on {s_ticker} - {ns_parser.n_days} days prediction"
-            plt.title(s_title)
+            plt.title(
+                f"{ns_parser.n_loops} loops - BACKTESTING: {model_name} on {s_ticker}"
+                f" - {ns_parser.n_days} days prediction"
+            )
         else:
             plt.title(
                 f"{ns_parser.n_loops} loops - {model_name} on {s_ticker} - {ns_parser.n_days} days prediction"

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -9,7 +9,7 @@ from sklearn.metrics import (
 )
 
 
-def price_prediction_color(val: int, last_val: int) -> str:
+def price_prediction_color(val: float, last_val: float) -> str:
     if float(val) > last_val:
         color = Fore.GREEN
     else:

--- a/gamestonk_terminal/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/prediction_techniques/pred_helper.py
@@ -28,6 +28,21 @@ def print_pretty_prediction(df_pred: pd.DataFrame, last_price: float):
         print(df_pred.to_string())
 
 
+def print_pretty_prediction_nn(df_pred: pd.DataFrame, last_price: float):
+    if gtff.USE_COLOR:
+        print(f"Actual price: {Fore.YELLOW}{last_price:.2f} ${Style.RESET_ALL}\n")
+        print("Prediction:")
+        print(
+            df_pred.applymap(
+                lambda x: price_prediction_color(x, last_val=last_price)
+            ).to_string()
+        )
+    else:
+        print(f"Actual price: {last_price:.2f} $\n")
+        print("Prediction:")
+        print(df_pred.to_string())
+
+
 def mean_absolute_percentage_error(y_true, y_pred):
     y_true, y_pred = np.array(y_true), np.array(y_pred)
     return np.mean(np.abs((y_true - y_pred) / y_true)) * 100


### PR DESCRIPTION
This aims to implement #240 .

As default I chose to plot the median prediction values. And filled the area between quantile 10 and 90%

Examples shown below:

![loops](https://user-images.githubusercontent.com/25267873/111932720-f475b300-8ab5-11eb-9b29-83535f62a4d3.png)

<img width="1006" alt="Captura de ecrã 2021-03-22, às 02 14 38" src="https://user-images.githubusercontent.com/25267873/111932716-f3448600-8ab5-11eb-956a-0b86b23c906c.png">
