### PR TITLE
Change news source from Finviz to News API

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ These are the ones where a key is necessary:
   * Polygon: https://polygon.io
   * Financial Modeling Prep: https://financialmodelingprep.com/developer
   * FRED: https://fred.stlouisfed.org/docs/api/api_key.html
+  * News API: https://newsapi.org
 
 When these are obtained, don't forget to update [config_terminal.py](/gamestonk_terminal/config_terminal.py).
 
-Alternatively, you can also set them to the following environment variables: GT_API_KEY_ALPHAVANTAGE, GT_API_KEY_FINANCIALMODELINGPREP, GT_API_KEY_QUANDL, GT_API_REDDIT_CLIENT_ID, GT_API_REDDIT_CLIENT_SECRET, GT_API_REDDIT_USERNAME, GT_API_REDDIT_USER_AGENT, GT_API_REDDIT_PASSWORD, GT_API_TWITTER_KEY, GT_API_TWITTER_SECRET_KEY, GT_API_TWITTER_BEARER_TOKEN, GT_API_POLYGON_KEY, GT_FRED_API_KEY.
+Alternatively, you can also set them to the following environment variables: GT_API_KEY_ALPHAVANTAGE, GT_API_KEY_FINANCIALMODELINGPREP, GT_API_KEY_QUANDL, GT_API_REDDIT_CLIENT_ID, GT_API_REDDIT_CLIENT_SECRET, GT_API_REDDIT_USERNAME, GT_API_REDDIT_USER_AGENT, GT_API_REDDIT_PASSWORD, GT_API_TWITTER_KEY, GT_API_TWITTER_SECRET_KEY, GT_API_TWITTER_BEARER_TOKEN, GT_API_POLYGON_KEY, GT_FRED_API_KEY, GT_API_NEWS_TOKEN.
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ Distributed under the MIT License. See [LICENSE](https://github.com/DidierRLopes
 * [VICE article](https://www.vice.com/en/article/qjp9vp/gamestonk-terminal-is-a-diy-meme-stock-version-of-bloomberg-terminal)
 * [Daily Fintech article](https://dailyfintech.com/2021/02/25/never-underestimate-bloomberg-but-here-are-5-reasons-why-the-gamestonk-terminal-is-a-contender/)
 * [HackerNews](https://news.ycombinator.com/item?id=26258773)
-* [Reddit](https://www.reddit.com/r/algotrading/comments/lrndzi/cant_afford_the_bloomberg_terminal_no_worries_i/)
+* [Reddit r/algotrading](https://www.reddit.com/r/algotrading/comments/m4uvza/gamestonk_terminal_the_next_best_thing_after/)
+* [Reddit r/Python](https://www.reddit.com/r/Python/comments/m515yk/gamestonk_terminal_the_equivalent_to_an/)
 
 
 <!-- MARKDOWN LINKS & IMAGES -->

--- a/gamestonk_terminal/config_terminal.py
+++ b/gamestonk_terminal/config_terminal.py
@@ -29,6 +29,9 @@ API_TWITTER_BEARER_TOKEN = os.getenv("GT_API_TWITTER_BEARER_TOKEN") or "REPLACE_
 # https://fred.stlouisfed.org/docs/api/api_key.html
 API_FRED_KEY = os.getenv("GT_FRED_API_KEY") or "REPLACE_ME"
 
+# https://newsapi.org
+API_NEWS_TOKEN = os.getenv("GT_API_NEWS_TOKEN") or "REPLACE_ME"
+
 # Robinhood
 RH_USERNAME = os.getenv("GT_RH_USERNAME") or "REPLACE_ME"
 RH_PASSWORD = os.getenv("GT_RH_PASSWORD") or "REPLACE_ME"

--- a/gamestonk_terminal/due_diligence/README.md
+++ b/gamestonk_terminal/due_diligence/README.md
@@ -35,7 +35,8 @@ Prints latest news about company, including date, title and web link. [Source: N
 
 * -n : Number of latest news being printed. Default 10.
 
-<img width="939" alt="news" src="https://user-images.githubusercontent.com/25267873/108609254-a8572600-73c4-11eb-9497-75530c50e82c.png">
+<img width="770" alt="Captura de ecrã 2021-03-22, às 22 47 42" src="https://user-images.githubusercontent.com/25267873/112070935-b2587a00-8b66-11eb-8dfb-0353fc83311d.png">
+
 
 ## red <a name="red"></a>
 

--- a/gamestonk_terminal/due_diligence/README.md
+++ b/gamestonk_terminal/due_diligence/README.md
@@ -3,7 +3,7 @@
 This menu aims to help in due-diligence of a pre-loaded stock, and the usage of the following commands along with an example will be exploited below.
 
 * [news](#news)
-  * latest news of the company [Finviz]
+  * latest news of the company [News API]
 * [red](#red)
   * gets due diligence from another user's post [Reddit]
 * [analyst](#analyst)
@@ -31,9 +31,9 @@ This menu aims to help in due-diligence of a pre-loaded stock, and the usage of 
 news [-n N_NUM]
 ```
 
-Prints latest news about company, including title and web link. [Source: Finviz]
+Prints latest news about company, including date, title and web link. [Source: News API]
 
-* -n : Number of latest news being printed. Default 5.
+* -n : Number of latest news being printed. Default 10.
 
 <img width="939" alt="news" src="https://user-images.githubusercontent.com/25267873/108609254-a8572600-73c4-11eb-9497-75530c50e82c.png">
 
@@ -54,7 +54,7 @@ Print top stock's due diligence from other users. [Source: Reddit]
 ## analyst <a name="analyst"></a>
 
 ```text
-usage: analyst 
+usage: analyst
 ```
 
 Print analyst prices and ratings of the company. The following fields are expected: date, analyst, category, price from, price to, and rating. [Source: Finviz]

--- a/gamestonk_terminal/due_diligence/dd_menu.py
+++ b/gamestonk_terminal/due_diligence/dd_menu.py
@@ -6,6 +6,7 @@ from gamestonk_terminal.due_diligence import finviz_api as fvz_api
 from gamestonk_terminal.due_diligence import market_watch_api as mw_api
 from gamestonk_terminal.due_diligence import quandl_api as q_api
 from gamestonk_terminal.due_diligence import reddit_api as r_api
+from gamestonk_terminal.due_diligence import news_api
 from gamestonk_terminal import feature_flags as gtff
 from gamestonk_terminal.helper_funcs import get_flair
 from gamestonk_terminal.menu import session
@@ -27,7 +28,7 @@ def print_due_diligence(s_ticker, s_start, s_interval):
     print("   q             quit this menu, and shows back to main menu")
     print("   quit          quit to abandon program")
     print("")
-    print("   news          latest news of the company [Finviz]")
+    print("   news          latest news of the company [News API]")
     print("   red           gets due diligence from another user's post [Reddit]")
     print("   analyst       analyst prices and ratings of the company [Finviz]")
     print("   rating        rating of the company from strong sell to strong buy [FMP]")
@@ -111,7 +112,7 @@ def dd_menu(df_stock, s_ticker, s_start, s_interval):
             fvz_api.insider(l_args, s_ticker)
 
         elif ns_known_args.cmd == "news":
-            fvz_api.news(l_args, s_ticker)
+            news_api.news(l_args, s_ticker)
 
         elif ns_known_args.cmd == "analyst":
             fvz_api.analyst(l_args, s_ticker)

--- a/gamestonk_terminal/due_diligence/news_api.py
+++ b/gamestonk_terminal/due_diligence/news_api.py
@@ -1,7 +1,6 @@
-import requests
-import json
 import argparse
 from datetime import datetime, timedelta
+import requests
 from gamestonk_terminal import config_terminal as cfg
 from gamestonk_terminal.helper_funcs import (
     check_positive,

--- a/gamestonk_terminal/due_diligence/news_api.py
+++ b/gamestonk_terminal/due_diligence/news_api.py
@@ -1,0 +1,66 @@
+import requests
+import json
+import argparse
+from datetime import datetime, timedelta
+from gamestonk_terminal import config_terminal as cfg
+from gamestonk_terminal.helper_funcs import (
+    check_positive,
+    parse_known_args_and_warn,
+)
+
+
+def news(l_args, s_ticker):
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="news",
+        description="""
+            Prints latest news about company, including date, title and web link. [Source: News API]
+        """,
+    )
+
+    parser.add_argument(
+        "-n",
+        "--num",
+        action="store",
+        dest="n_num",
+        type=check_positive,
+        default=10,
+        help="Number of latest news being printed.",
+    )
+
+    try:
+        ns_parser = parse_known_args_and_warn(parser, l_args)
+        if not ns_parser:
+            return
+
+        s_from = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+
+        response = requests.get(
+            f"https://newsapi.org/v2/everything?q={s_ticker}&from={s_from}"
+            f"&sortBy=publishedAt&language=en&apiKey={cfg.API_NEWS_TOKEN}",
+        )
+
+        # Check that the API response was successful
+        if response.status_code != 200:
+            print("Invalid News API token\n")
+
+        else:
+            print(
+                f"{response.json()['totalResults']} news articles from {s_ticker} were found since {s_from}\n"
+            )
+
+            for idx, article in enumerate(response.json()["articles"]):
+                print(
+                    article["publishedAt"].replace("T", " ").replace("Z", ""),
+                    " ",
+                    article["title"],
+                )
+                # Unnecessary to use name of the source because contained in link article["source"]["name"]
+                print(article["url"])
+                print("")
+
+                if idx >= ns_parser.n_num - 1:
+                    break
+
+    except Exception as e:
+        print(e, "\n")


### PR DESCRIPTION
This change was required due to #255 because:
1. Finviz only gives news titles + link, not sorted
2. Finviz is limited in the sources by focusing on Yahoo Finance mainly

News API seems to be the right way to go with this