### PR TITLE
remove "fuck these guys" from Robinhood

### DIFF
--- a/gamestonk_terminal/portfolio/port_controller.py
+++ b/gamestonk_terminal/portfolio/port_controller.py
@@ -56,8 +56,8 @@ class PortfolioController:
             f"\nCurrent Brokers : {('None', ', '.join(broker_list))[bool(broker_list)]}"
         )
         print("\nCurrently Supported :")
-        print("   rh             Robinhood - fuck these guys")
-        print("   alp            Alpaca ")
+        print("   rh             Robinhood")
+        print("   alp            Alpaca")
         print("   ally           Ally Invest")
         print("\nCommands (login required):")
         print("\nRobinhood:")


### PR DESCRIPTION
I don't like Robinhood either, but not everyone who is going to use/see this in the future is going to have the same context. Let's keep the code clean and professional.