### PR TITLE
Add view command to technical analysis with trendlines

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,6 +68,7 @@
 * [x] Add initial implementation of trendline analysis (@aia) - [PR #173](https://github.com/DidierRLopes/GamestonkTerminal/pull/173)
 * [x] Add technical summary report provided by FinBrain (@didier) - [PR #294](https://github.com/DidierRLopes/GamestonkTerminal/pull/294)
 * [x] Add recommendation based on technical indicators from Tradingview (@didier) - [PR #301](https://github.com/DidierRLopes/GamestonkTerminal/pull/301)
+* [x] Add view of stock historical price with trendlines (support, resistance) by Finviz (@didier) - [PR #317](https://github.com/DidierRLopes/GamestonkTerminal/pull/317)
 
 **NEXT**
 * [ ] Add auto-recognition of major TA patterns (@didier)

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -103,8 +103,10 @@ class DiscoveryController:
         # Due to Finviz implementation of Spectrum, we delete the generated spectrum figure
         # after saving it and displaying it to the user
         if self.spectrum_img_to_delete:
-            os.remove(self.spectrum_img_to_delete + ".jpg")
-            self.spectrum_img_to_delete = ""
+            # Confirm that file exists
+            if os.path.isfile(self.spectrum_img_to_delete + ".jpg"):
+                os.remove(self.spectrum_img_to_delete + ".jpg")
+                self.spectrum_img_to_delete = ""
 
         return getattr(
             self, "call_" + known_args.cmd, lambda: "Command not recognized!"

--- a/gamestonk_terminal/technical_analysis/README.md
+++ b/gamestonk_terminal/technical_analysis/README.md
@@ -2,6 +2,8 @@
 
 This menu aims to perform a technical analysis on a pre-loaded ticker chart, and the usage of the following commands along with an example will be exploited below.
 
+ * [view](#view)
+    - view historical data and trendlines [Finviz]
  * [summary](#summary)
     - technical summary report [FinBrain API]
  * [recom](#recom)
@@ -43,12 +45,22 @@ This menu aims to perform a technical analysis on a pre-loaded ticker chart, and
 
 **S/O to https://github.com/twopirllc/pandas-ta** _Owing to this library, it is fairly easy to add other technical indicators. So, let me know if there's any that you would like. Personally I use mostly these ones, hence why I didn't add more._
 
+## view  <a name="view"></a>
+```
+usage: view
+```
+
+View historical price with trendlines. [Source: Finviz]
+
+![aapl](https://user-images.githubusercontent.com/25267873/113757843-02107700-970b-11eb-99ab-eb9b1312547f.png)
+
+
 ## summary  <a name="summary"></a>
 ```
 usage: summary
 ```
 
-Technical summary report provided by FinBrain's API. FinBrain Technologies develops deep learning algorithms for financial analysis and prediction, which currently serves traders from more than 150 countries all around the world. [Source: See https://finbrain.tech]
+Technical summary report provided by FinBrain's API. FinBrain Technologies develops deep learning algorithms for financial analysis and prediction, which currently serves traders from more than 150 countries all around the world. [Source: https://finbrain.tech]
 
 <img width="976" alt="Captura de ecrã 2021-03-29, às 00 31 29" src="https://user-images.githubusercontent.com/25267873/112772089-db758080-9026-11eb-93d5-9fd7a4b40380.png">
 

--- a/gamestonk_terminal/technical_analysis/finviz_view.py
+++ b/gamestonk_terminal/technical_analysis/finviz_view.py
@@ -1,0 +1,43 @@
+""" Finviz View """
+__docformat__ = "numpy"
+
+import argparse
+from typing import List
+from gamestonk_terminal.helper_funcs import parse_known_args_and_warn
+from finvizfinance.quote import finvizfinance
+from PIL import Image
+
+
+def view(other_args: List[str], ticker: str):
+    """View historical price with trendlines. [Source: Finviz]
+
+    Parameters
+    ----------
+    other_args : List[str]
+        argparse other args
+    ticker: str
+        stock ticker
+    """
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="view",
+        description="""
+            View historical price with trendlines. [Source: Finviz]
+        """,
+    )
+
+    try:
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
+
+        stock = finvizfinance(ticker)
+        stock.TickerCharts()
+
+        img = Image.open(ticker + ".jpg")
+        img.show()
+
+        print("")
+
+    except SystemExit:
+        print("")


### PR DESCRIPTION
While looking into finviz API I found this graph interesting, which is the same as `candle` but with some more info around. 

![aapl](https://user-images.githubusercontent.com/25267873/113758306-97137000-970b-11eb-8756-ed4a85f032d5.png)

I thought it would be good to also have a view command with the support/resistance trendlines in the technical analysis menu, and thought that we could add this so that we have another source of data, and not the same repeated command.

Let me know if you disagree, regarding:
- Having a view command on technical analysis
- Not using the same source as `candle` with a really similar outcome
