### PR TITLE
add market_news and news_article to disc menu

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,7 @@
 * [x] Top Losers (@didier) - [PR #171](https://github.com/DidierRLopes/GamestonkTerminal/pull/171)
 * [x] ARK orders (@aia) - [PR #140](https://github.com/DidierRLopes/GamestonkTerminal/pull/140)
 * [x] Analyse sectors/industry performance, overview and valuation from Finviz (@didier) - [PR #315](https://github.com/DidierRLopes/GamestonkTerminal/pull/315)
+* [x] Add latest and trending news commands (@hinxx) - [PR #347](https://github.com/DidierRLopes/GamestonkTerminal/pull/347)
 
 **NEXT**
 

--- a/gamestonk_terminal/README.md
+++ b/gamestonk_terminal/README.md
@@ -79,6 +79,8 @@ Command|Description|Source
 `valuation`     |valuation of sectors, industry, country |[Finviz](https://finviz.com)
 `performance`   |performance of sectors, industry, country |[Finviz](https://finviz.com)
 `spectrum`      |spectrum of sectors, industry, country |[Finviz](https://finviz.com)
+`latest`        |latest news |[Seeking Alpha](https://seekingalpha.com/)
+`trending`      |trending news |[Seeking Alpha](https://seekingalpha.com/)
 
 &nbsp;
 

--- a/gamestonk_terminal/discovery/README.md
+++ b/gamestonk_terminal/discovery/README.md
@@ -32,6 +32,10 @@ This menu aims to discover new stocks, and the usage of the following commands a
   * performance of sectors, industry, country [Finviz]
 * [spectrum](#spectrum)
   * spectrum of sectors, industry, country [Finviz]
+* [latest](#latest)
+  * latest news [Seeking Alpha]
+* [trending](#trending)
+  * trending news [Seeking Alpha]
 
 
 ## map <a name="map"></a>
@@ -218,3 +222,30 @@ Spectrum of sectors, industry, country. [Source: Finviz]
 * -g : Data group (sector, industry or country). Default: Sector.
 
 ![cntry_spec](https://user-images.githubusercontent.com/25267873/113639067-48fd5e80-9670-11eb-95cf-0931845ddd12.png)
+
+
+## latest <a name="latest"></a>
+
+```
+usage: latest [-i N_ID] [-n N_NUM]
+```
+
+Latest news articles. [Source: Seeking Alpha]
+* -i : article number found on Seeking Alpha website
+* -n : number of latest articles being printed. Default 10.
+
+<img width="1208" alt="latest" src="https://user-images.githubusercontent.com/25267873/115089633-926c6a00-9f0a-11eb-9d0e-1eedfd8ba7ce.png">
+
+
+## trending <a name="trending"></a>
+
+```
+usage: trending [-i N_ID] [-n N_NUM]
+```
+
+Trending news articles. [Source: Seeking Alpha]
+* -i : article number found on Seeking Alpha website
+* -n : number of trending articles being printed. Default 10.
+
+<img width="1213" alt="trending" src="https://user-images.githubusercontent.com/25267873/115089640-96988780-9f0a-11eb-9ca7-70a245fa3960.png">
+

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -46,6 +46,8 @@ class DiscoveryController:
         "valuation",
         "performance",
         "spectrum",
+        "market_news",
+        "news_article"
     ]
 
     def __init__(self):
@@ -87,6 +89,8 @@ class DiscoveryController:
         print("   valuation      valuation of sectors, industry, country [Finviz]")
         print("   performance    performance of sectors, industry, country [Finviz]")
         print("   spectrum       spectrum of sectors, industry, country [Finviz]")
+        print("   market_news    latest news [SeekingAlpha]")
+        print("   news_article   news article [SeekingAlpha]")
         print("")
 
     def switch(self, an_input: str):
@@ -186,6 +190,14 @@ class DiscoveryController:
         self.spectrum_img_to_delete = finviz_view.view_group_data(
             other_args, "spectrum"
         )
+
+    def call_market_news(self, other_args: List[str]):
+        """Process market_news command"""
+        seeking_alpha_view.articles_list_view(other_args)
+
+    def call_news_article(self, other_args: List[str]):
+        """Process news_article command"""
+        seeking_alpha_view.news_article_view(other_args)
 
 
 def menu():

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -47,6 +47,7 @@ class DiscoveryController:
         "performance",
         "spectrum",
         "latest",
+        "trending",
         "news_article"
     ]
 
@@ -90,6 +91,7 @@ class DiscoveryController:
         print("   performance    performance of sectors, industry, country [Finviz]")
         print("   spectrum       spectrum of sectors, industry, country [Finviz]")
         print("   latest         latest news [SeekingAlpha]")
+        print("   trending       trending news [SeekingAlpha]")
         print("   news_article   news article [SeekingAlpha]")
         print("")
 
@@ -194,6 +196,10 @@ class DiscoveryController:
     def call_latest(self, other_args: List[str]):
         """Process latest command"""
         seeking_alpha_view.latest_news_view(other_args)
+
+    def call_trending(self, other_args: List[str]):
+        """Process trending command"""
+        seeking_alpha_view.trending_news_view(other_args)
 
     def call_news_article(self, other_args: List[str]):
         """Process news_article command"""

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -48,7 +48,7 @@ class DiscoveryController:
         "spectrum",
         "latest",
         "trending",
-        "news_article"
+        "news_article",
     ]
 
     def __init__(self):

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -46,7 +46,7 @@ class DiscoveryController:
         "valuation",
         "performance",
         "spectrum",
-        "market_news",
+        "latest",
         "news_article"
     ]
 
@@ -89,7 +89,7 @@ class DiscoveryController:
         print("   valuation      valuation of sectors, industry, country [Finviz]")
         print("   performance    performance of sectors, industry, country [Finviz]")
         print("   spectrum       spectrum of sectors, industry, country [Finviz]")
-        print("   market_news    latest news [SeekingAlpha]")
+        print("   latest         latest news [SeekingAlpha]")
         print("   news_article   news article [SeekingAlpha]")
         print("")
 
@@ -191,9 +191,9 @@ class DiscoveryController:
             other_args, "spectrum"
         )
 
-    def call_market_news(self, other_args: List[str]):
-        """Process market_news command"""
-        seeking_alpha_view.articles_list_view(other_args)
+    def call_latest(self, other_args: List[str]):
+        """Process latest command"""
+        seeking_alpha_view.latest_news_view(other_args)
 
     def call_news_article(self, other_args: List[str]):
         """Process news_article command"""

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -48,7 +48,6 @@ class DiscoveryController:
         "spectrum",
         "latest",
         "trending",
-        "news_article",
     ]
 
     def __init__(self):
@@ -90,9 +89,8 @@ class DiscoveryController:
         print("   valuation      valuation of sectors, industry, country [Finviz]")
         print("   performance    performance of sectors, industry, country [Finviz]")
         print("   spectrum       spectrum of sectors, industry, country [Finviz]")
-        print("   latest         latest news [SeekingAlpha]")
-        print("   trending       trending news [SeekingAlpha]")
-        print("   news_article   news article [SeekingAlpha]")
+        print("   latest         latest news [Seeking Alpha]")
+        print("   trending       trending news [Seeking Alpha]")
         print("")
 
     def switch(self, an_input: str):
@@ -200,10 +198,6 @@ class DiscoveryController:
     def call_trending(self, other_args: List[str]):
         """Process trending command"""
         seeking_alpha_view.trending_news_view(other_args)
-
-    def call_news_article(self, other_args: List[str]):
-        """Process news_article command"""
-        seeking_alpha_view.news_article_view(other_args)
 
 
 def menu():

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -67,3 +67,96 @@ def get_next_earnings(pages: int) -> DataFrame:
     df_earnings = df_earnings.set_index("Date")
 
     return df_earnings
+
+
+def get_articles_html(url_articles: str) -> str:
+    """Wraps HTTP requests.get for testibility
+
+    Parameters
+    ----------
+    url_articles : str
+        Articles URL
+
+    Returns
+    -------
+    str
+        HTML page of articles
+    """
+    articles_html = requests.get(
+        url_articles, headers={"User-Agent": get_user_agent()}
+    ).text
+
+    return articles_html
+
+
+def get_article_list(pages: int) -> list:
+    """Returns a list of recent articles
+
+    Parameters
+    ----------
+    pages : int
+        Number of pages
+
+    Returns
+    -------
+    list
+        Latest articles list
+    """
+
+    articles = list()
+    url_articles = "https://seekingalpha.com/market-news"
+    for idx in range(0, pages):
+        text_soup_articles = BeautifulSoup(
+            get_articles_html(url_articles),
+            "lxml",
+        )
+
+        for item_row in text_soup_articles.findAll("li", {"class": "item"}):
+            item = item_row.find("a", {"class": "add-source-assigned"})
+            if item is None:
+                continue
+            article_url = item['href']
+            if not article_url.startswith('/news/'):
+                continue
+            article_id = article_url.split('/')[2].split('-')[0]
+            articles.append({
+                'title': item.text,
+                'date': item_row['data-last-date'],
+                'url': "https://seekingalpha.com"+article_url,
+                'id': article_id
+            })
+
+        url_articles = (
+            f"https://seekingalpha.com/market-news/{idx+1}"
+        )
+
+    return articles
+
+
+def get_article_data(article_id: int) -> dict:
+    """Returns an article
+
+    Parameters
+    ----------
+    article_id : int
+        Article ID
+
+    Returns
+    -------
+    dict
+        Article data
+    """
+
+    article_url = f"https://seekingalpha.com/api/v3/news/{article_id}"
+    response = requests.get(article_url, headers={"User-Agent": get_user_agent()})
+    jdata = response.json()
+    content = jdata['data']['attributes']['content'].replace('</li>', '</li>\n')
+    content = BeautifulSoup(content, features="html.parser").get_text()
+
+    article = {
+        'title': jdata['data']['attributes']['title'],
+        'date': jdata['data']['attributes']['lastModified'],
+        'content': content
+    }
+
+    return article

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -89,13 +89,13 @@ def get_articles_html(url_articles: str) -> str:
     return articles_html
 
 
-def get_article_list(pages: int) -> list:
-    """Returns a list of recent articles
+def get_article_list(num: int) -> list:
+    """Returns a list of latest articles
 
     Parameters
     ----------
     pages : int
-        Number of pages
+        Number of articles
 
     Returns
     -------
@@ -104,8 +104,9 @@ def get_article_list(pages: int) -> list:
     """
 
     articles = list()
-    url_articles = "https://seekingalpha.com/market-news"
-    for idx in range(0, pages):
+    page = 1
+    url_articles = f"https://seekingalpha.com/market-news/{page}"
+    while len(articles) < num:
         text_soup_articles = BeautifulSoup(
             get_articles_html(url_articles),
             "lxml",
@@ -121,14 +122,13 @@ def get_article_list(pages: int) -> list:
             article_id = article_url.split('/')[2].split('-')[0]
             articles.append({
                 'title': item.text,
-                'date': item_row['data-last-date'],
+                'publishedAt': item_row['data-last-date'],
                 'url': "https://seekingalpha.com"+article_url,
                 'id': article_id
             })
 
-        url_articles = (
-            f"https://seekingalpha.com/market-news/{idx+1}"
-        )
+        page += 1
+        url_articles = f"https://seekingalpha.com/market-news/{page}"
 
     return articles
 

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -192,7 +192,8 @@ def get_article_data(article_id: int) -> dict:
 
     article = {
         'title': jdata['data']['attributes']['title'],
-        'date': jdata['data']['attributes']['lastModified'],
+        'publishedAt': jdata['data']['attributes']['lastModified'],
+        'url': "https://seekingalpha.com"+jdata['data']['links']['self'],
         'content': content
     }
 

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -1,6 +1,7 @@
 """ Seeking Alpha Model """
 __docformat__ = "numpy"
 
+from typing import List
 import requests
 from bs4 import BeautifulSoup
 import pandas as pd
@@ -89,7 +90,7 @@ def get_articles_html(url_articles: str) -> str:
     return articles_html
 
 
-def get_article_list(num: int) -> list:
+def get_article_list(num: int) -> List[dict]:
     """Returns a list of latest articles
 
     Parameters
@@ -103,7 +104,7 @@ def get_article_list(num: int) -> list:
         Latest articles list
     """
 
-    articles = list()
+    articles: List[dict] = []
     page = 1
     url_articles = f"https://seekingalpha.com/market-news/{page}"
     while len(articles) < num:
@@ -116,16 +117,18 @@ def get_article_list(num: int) -> list:
             item = item_row.find("a", {"class": "add-source-assigned"})
             if item is None:
                 continue
-            article_url = item['href']
-            if not article_url.startswith('/news/'):
+            article_url = item["href"]
+            if not article_url.startswith("/news/"):
                 continue
-            article_id = article_url.split('/')[2].split('-')[0]
-            articles.append({
-                'title': item.text,
-                'publishedAt': item_row['data-last-date'],
-                'url': "https://seekingalpha.com"+article_url,
-                'id': article_id
-            })
+            article_id = article_url.split("/")[2].split("-")[0]
+            articles.append(
+                {
+                    "title": item.text,
+                    "publishedAt": item_row["data-last-date"],
+                    "url": "https://seekingalpha.com" + article_url,
+                    "id": article_id,
+                }
+            )
 
         page += 1
         url_articles = f"https://seekingalpha.com/market-news/{page}"
@@ -156,16 +159,18 @@ def get_trending_list(num: int) -> list:
         print("Invalid response\n")
     else:
         for item in response.json():
-            article_url = item['uri']
-            if not article_url.startswith('/news/'):
+            article_url = item["uri"]
+            if not article_url.startswith("/news/"):
                 continue
-            article_id = article_url.split('/')[2].split('-')[0]
-            articles.append({
-                'title': item['title'],
-                'publishedAt': item['publish_on'],
-                'url': "https://seekingalpha.com"+article_url,
-                'id': article_id
-            })
+            article_id = article_url.split("/")[2].split("-")[0]
+            articles.append(
+                {
+                    "title": item["title"],
+                    "publishedAt": item["publish_on"],
+                    "url": "https://seekingalpha.com" + article_url,
+                    "id": article_id,
+                }
+            )
 
     return articles
 
@@ -187,14 +192,14 @@ def get_article_data(article_id: int) -> dict:
     article_url = f"https://seekingalpha.com/api/v3/news/{article_id}"
     response = requests.get(article_url, headers={"User-Agent": get_user_agent()})
     jdata = response.json()
-    content = jdata['data']['attributes']['content'].replace('</li>', '</li>\n')
+    content = jdata["data"]["attributes"]["content"].replace("</li>", "</li>\n")
     content = BeautifulSoup(content, features="html.parser").get_text()
 
     article = {
-        'title': jdata['data']['attributes']['title'],
-        'publishedAt': jdata['data']['attributes']['lastModified'],
-        'url': "https://seekingalpha.com"+jdata['data']['links']['self'],
-        'content': content
+        "title": jdata["data"]["attributes"]["title"],
+        "publishedAt": jdata["data"]["attributes"]["lastModified"],
+        "url": "https://seekingalpha.com" + jdata["data"]["links"]["self"],
+        "content": content,
     }
 
     return article

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -6,6 +6,7 @@ import requests
 from bs4 import BeautifulSoup
 import pandas as pd
 from pandas.core.frame import DataFrame
+from datetime import datetime
 
 from gamestonk_terminal.helper_funcs import get_user_agent
 
@@ -121,10 +122,13 @@ def get_article_list(num: int) -> List[dict]:
             if not article_url.startswith("/news/"):
                 continue
             article_id = article_url.split("/")[2].split("-")[0]
+
             articles.append(
                 {
                     "title": item.text,
-                    "publishedAt": item_row["data-last-date"],
+                    "publishedAt": datetime.strptime(
+                        item_row["data-last-date"], "%Y-%m-%d %H:%M:%S %z"
+                    ).strftime("%Y-%m-%d %H:%M:%S"),
                     "url": "https://seekingalpha.com" + article_url,
                     "id": article_id,
                 }
@@ -166,7 +170,7 @@ def get_trending_list(num: int) -> list:
             articles.append(
                 {
                     "title": item["title"],
-                    "publishedAt": item["publish_on"],
+                    "publishedAt": item["publish_on"][: item["publish_on"].rfind(".")],
                     "url": "https://seekingalpha.com" + article_url,
                     "id": article_id,
                 }

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -133,6 +133,43 @@ def get_article_list(num: int) -> list:
     return articles
 
 
+def get_trending_list(num: int) -> list:
+    """Returns a list of trending articles
+
+    Parameters
+    ----------
+    pages : int
+        Number of articles
+
+    Returns
+    -------
+    list
+        Trending articles list
+    """
+
+    articles = list()
+    url_articles = "https://seekingalpha.com/news/trending_news"
+    response = requests.get(url_articles, headers={"User-Agent": get_user_agent()})
+
+    # Check that the API response was successful
+    if response.status_code != 200:
+        print("Invalid response\n")
+    else:
+        for item in response.json():
+            article_url = item['uri']
+            if not article_url.startswith('/news/'):
+                continue
+            article_id = article_url.split('/')[2].split('-')[0]
+            articles.append({
+                'title': item['title'],
+                'publishedAt': item['publish_on'],
+                'url': "https://seekingalpha.com"+article_url,
+                'id': article_id
+            })
+
+    return articles
+
+
 def get_article_data(article_id: int) -> dict:
     """Returns an article
 

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -65,3 +65,73 @@ def earnings_release_dates_view(other_args: List[str]):
             ].to_string(index=False, header=False)
         )
         print("")
+
+
+def articles_list_view(other_args: List[str]):
+    """Prints a news article list
+
+    Parameters
+    ----------
+    other_args : List[str]
+        argparse other args - ["-p", "20", "-n", "5"]
+    """
+
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="up_articles",
+        description="""Latest articles. [Source: Seeking Alpha]""",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--pages",
+        action="store",
+        dest="n_pages",
+        type=check_positive,
+        default=1,
+        help="Number of pages from Seeking Alpha website.",
+    )
+
+    ns_parser = parse_known_args_and_warn(parser, other_args)
+    if not ns_parser:
+        return
+
+    articles = seeking_alpha_model.get_article_list(ns_parser.n_pages)
+    for article in articles:
+        print(article['id'], '-', article['title'], '(', article['url'], ')')
+
+
+def news_article_view(other_args: List[str]):
+    """Prints a news article
+
+    Parameters
+    ----------
+    other_args : List[str]
+        argparse other args - ["-i", "3681944"]
+    """
+
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="up_article",
+        description="""News article. [Source: Seeking Alpha]""",
+    )
+
+    parser.add_argument(
+        "-i",
+        "--id",
+        action="store",
+        dest="n_id",
+        type=check_positive,
+        default=-1,
+        help="Article number found on Seeking Alpha website.",
+    )
+
+    ns_parser = parse_known_args_and_warn(parser, other_args)
+    if not ns_parser:
+        return
+    if ns_parser.n_id == -1:
+        return
+
+    article = seeking_alpha_model.get_article_data(ns_parser.n_id)
+    print(article['date'], article['title'])
+    print(article['content'])

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -189,5 +189,7 @@ def news_article_view(other_args: List[str]):
         return
 
     article = seeking_alpha_model.get_article_data(ns_parser.n_id)
-    print(article['date'], article['title'])
+    print(article['publishedAt'], " ", article['title'])
+    print(article["url"])
+    print("")
     print(article['content'])

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -73,15 +73,22 @@ def latest_news_view(other_args: List[str]):
     Parameters
     ----------
     other_args : List[str]
-        argparse other args - ["-n", "5"]
+        argparse other args - ["-i", "123123", "-n", "5"]
     """
-
     parser = argparse.ArgumentParser(
         add_help=False,
         prog="latest",
         description="""Latest news articles. [Source: Seeking Alpha]""",
     )
-
+    parser.add_argument(
+        "-i",
+        "--id",
+        action="store",
+        dest="n_id",
+        type=check_positive,
+        default=-1,
+        help="article number found on Seeking Alpha website",
+    )
     parser.add_argument(
         "-n",
         "--num",
@@ -92,24 +99,44 @@ def latest_news_view(other_args: List[str]):
         help="number of latest articles being printed",
     )
 
+    if other_args:
+        if "-" not in other_args[0]:
+            other_args.insert(0, "-i")
+
     ns_parser = parse_known_args_and_warn(parser, other_args)
     if not ns_parser:
         return
 
-    articles = seeking_alpha_model.get_article_list(ns_parser.n_num)
-    for idx, article in enumerate(articles):
+    # User wants to see all latest news
+    if ns_parser.n_id == -1:
+        articles = seeking_alpha_model.get_article_list(ns_parser.n_num)
+        for idx, article in enumerate(articles):
+            print(
+                article["publishedAt"].replace("T", " ").replace("Z", ""),
+                "-",
+                article["id"],
+                "-",
+                article["title"],
+            )
+            print(article["url"])
+            print("")
+
+            if idx >= ns_parser.n_num - 1:
+                break
+
+    # User wants to access specific article
+    else:
+        article = seeking_alpha_model.get_article_data(ns_parser.n_id)
         print(
-            article["publishedAt"].replace("T", " ").replace("Z", ""),
-            "-",
-            article["id"],
-            "-",
+            article["publishedAt"][: article["publishedAt"].rfind(":") - 3].replace(
+                "T", " "
+            ),
+            " ",
             article["title"],
         )
         print(article["url"])
         print("")
-
-        if idx >= ns_parser.n_num - 1:
-            break
+        print(article["content"])
 
 
 def trending_news_view(other_args: List[str]):
@@ -118,15 +145,22 @@ def trending_news_view(other_args: List[str]):
     Parameters
     ----------
     other_args : List[str]
-        argparse other args - ["-n", "5"]
+        argparse other args - ["i", "123123", "-n", "5"]
     """
-
     parser = argparse.ArgumentParser(
         add_help=False,
         prog="trending",
         description="""Trending news articles. [Source: Seeking Alpha]""",
     )
-
+    parser.add_argument(
+        "-i",
+        "--id",
+        action="store",
+        dest="n_id",
+        type=check_positive,
+        default=-1,
+        help="article number found on Seeking Alpha website",
+    )
     parser.add_argument(
         "-n",
         "--num",
@@ -137,59 +171,41 @@ def trending_news_view(other_args: List[str]):
         help="number of trending articles being printed",
     )
 
+    if other_args:
+        if "-" not in other_args[0]:
+            other_args.insert(0, "-i")
+
     ns_parser = parse_known_args_and_warn(parser, other_args)
     if not ns_parser:
         return
 
-    articles = seeking_alpha_model.get_trending_list(ns_parser.n_num)
-    for idx, article in enumerate(articles):
+    # User wants to see all trending articles
+    if ns_parser.n_id == -1:
+        articles = seeking_alpha_model.get_trending_list(ns_parser.n_num)
+        for idx, article in enumerate(articles):
+            print(
+                article["publishedAt"].replace("T", " ").replace("Z", ""),
+                "-",
+                article["id"],
+                "-",
+                article["title"],
+            )
+            print(article["url"])
+            print("")
+
+            if idx >= ns_parser.n_num - 1:
+                break
+
+    # User wants to access specific article
+    else:
+        article = seeking_alpha_model.get_article_data(ns_parser.n_id)
         print(
-            article["publishedAt"].replace("T", " ").replace("Z", ""),
-            "-",
-            article["id"],
-            "-",
+            article["publishedAt"][: article["publishedAt"].rfind(":") - 3].replace(
+                "T", " "
+            ),
+            " ",
             article["title"],
         )
         print(article["url"])
         print("")
-
-        if idx >= ns_parser.n_num - 1:
-            break
-
-
-def news_article_view(other_args: List[str]):
-    """Prints a news article
-
-    Parameters
-    ----------
-    other_args : List[str]
-        argparse other args - ["-i", "3681944"]
-    """
-
-    parser = argparse.ArgumentParser(
-        add_help=False,
-        prog="up_article",
-        description="""News article. [Source: Seeking Alpha]""",
-    )
-
-    parser.add_argument(
-        "-i",
-        "--id",
-        action="store",
-        dest="n_id",
-        type=check_positive,
-        default=-1,
-        help="article number found on Seeking Alpha website",
-    )
-
-    ns_parser = parse_known_args_and_warn(parser, other_args)
-    if not ns_parser:
-        return
-    if ns_parser.n_id == -1:
-        return
-
-    article = seeking_alpha_model.get_article_data(ns_parser.n_id)
-    print(article["publishedAt"], " ", article["title"])
-    print(article["url"])
-    print("")
-    print(article["content"])
+        print(article["content"])

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -112,6 +112,51 @@ def latest_news_view(other_args: List[str]):
             break
 
 
+def trending_news_view(other_args: List[str]):
+    """Prints the trending news article list
+
+    Parameters
+    ----------
+    other_args : List[str]
+        argparse other args - ["-n", "5"]
+    """
+
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="trending",
+        description="""Trending news articles. [Source: Seeking Alpha]""",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--num",
+        action="store",
+        dest="n_num",
+        type=check_positive,
+        default=10,
+        help="number of trending articles being printed.",
+    )
+
+    ns_parser = parse_known_args_and_warn(parser, other_args)
+    if not ns_parser:
+        return
+
+    articles = seeking_alpha_model.get_trending_list(ns_parser.n_num)
+    for idx, article in enumerate(articles):
+        print(
+            article["publishedAt"].replace("T", " ").replace("Z", ""),
+            "-",
+            article['id'],
+            "-",
+            article["title"],
+        )
+        print(article["url"])
+        print("")
+
+        if idx >= ns_parser.n_num - 1:
+            break
+
+
 def news_article_view(other_args: List[str]):
     """Prints a news article
 

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -89,7 +89,7 @@ def latest_news_view(other_args: List[str]):
         dest="n_num",
         type=check_positive,
         default=10,
-        help="number of latest articles being printed.",
+        help="number of latest articles being printed",
     )
 
     ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -101,7 +101,7 @@ def latest_news_view(other_args: List[str]):
         print(
             article["publishedAt"].replace("T", " ").replace("Z", ""),
             "-",
-            article['id'],
+            article["id"],
             "-",
             article["title"],
         )
@@ -134,7 +134,7 @@ def trending_news_view(other_args: List[str]):
         dest="n_num",
         type=check_positive,
         default=10,
-        help="number of trending articles being printed.",
+        help="number of trending articles being printed",
     )
 
     ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -146,7 +146,7 @@ def trending_news_view(other_args: List[str]):
         print(
             article["publishedAt"].replace("T", " ").replace("Z", ""),
             "-",
-            article['id'],
+            article["id"],
             "-",
             article["title"],
         )
@@ -179,7 +179,7 @@ def news_article_view(other_args: List[str]):
         dest="n_id",
         type=check_positive,
         default=-1,
-        help="Article number found on Seeking Alpha website.",
+        help="article number found on Seeking Alpha website",
     )
 
     ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -189,7 +189,7 @@ def news_article_view(other_args: List[str]):
         return
 
     article = seeking_alpha_model.get_article_data(ns_parser.n_id)
-    print(article['publishedAt'], " ", article['title'])
+    print(article["publishedAt"], " ", article["title"])
     print(article["url"])
     print("")
-    print(article['content'])
+    print(article["content"])

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -67,38 +67,49 @@ def earnings_release_dates_view(other_args: List[str]):
         print("")
 
 
-def articles_list_view(other_args: List[str]):
-    """Prints a news article list
+def latest_news_view(other_args: List[str]):
+    """Prints the latest news article list
 
     Parameters
     ----------
     other_args : List[str]
-        argparse other args - ["-p", "20", "-n", "5"]
+        argparse other args - ["-n", "5"]
     """
 
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="up_articles",
-        description="""Latest articles. [Source: Seeking Alpha]""",
+        prog="latest",
+        description="""Latest news articles. [Source: Seeking Alpha]""",
     )
 
     parser.add_argument(
-        "-p",
-        "--pages",
+        "-n",
+        "--num",
         action="store",
-        dest="n_pages",
+        dest="n_num",
         type=check_positive,
-        default=1,
-        help="Number of pages from Seeking Alpha website.",
+        default=10,
+        help="number of latest articles being printed.",
     )
 
     ns_parser = parse_known_args_and_warn(parser, other_args)
     if not ns_parser:
         return
 
-    articles = seeking_alpha_model.get_article_list(ns_parser.n_pages)
-    for article in articles:
-        print(article['id'], '-', article['title'], '(', article['url'], ')')
+    articles = seeking_alpha_model.get_article_list(ns_parser.n_num)
+    for idx, article in enumerate(articles):
+        print(
+            article["publishedAt"].replace("T", " ").replace("Z", ""),
+            "-",
+            article['id'],
+            "-",
+            article["title"],
+        )
+        print(article["url"])
+        print("")
+
+        if idx >= ns_parser.n_num - 1:
+            break
 
 
 def news_article_view(other_args: List[str]):


### PR DESCRIPTION
Here is my first attempt at contributing to this awesome project!

I find it useful to see the latest _stock_ news. Seeking Alpha page https://seekingalpha.com/market-news was used as a source of articles, which is also quite lively and up to date.

Two commands were introduced to the `disc` menu (maybe there is better place to have this?)

```
   market_news    latest news [SeekingAlpha]
   news_article   news article [SeekingAlpha]
```

The `market_news` command will fetch the aforementioned web page and take out article titles and present user with the list of titles, URLs and IDs. For example:

```
(✨) (disc)> market_news
3682093 - National Retail Properties declares $0.52 dividend ( https://seekingalpha.com/news/3682093-national-retail-properties-declares-0_52-dividend )
3682101 - Oxford Biomedica reported FY prelim revenue growth of 37% ( https://seekingalpha.com/news/3682101-oxford-biomedica-reported-fy-prelim-revenue-growth-of-37 )
3682092 - CSW Industrials hikes dividend by 11% to $0.15 per share ( https://seekingalpha.com/news/3682092-csw-industrials-hikes-dividend-by-11-to-015-per-share )
3682100 - UPS higher after Citi issues positive catalyst watch ( https://seekingalpha.com/news/3682100-ups-higher-after-citi-issues-positive-catalyst-watch )
3682099 - Empire State Manufacturing Index surges in April ( https://seekingalpha.com/news/3682099-empire-state-manufacturing-index-surges-in-april )
3682098 - Regulus Therapeutics completes dosing in early-stage kidney disease trial ( https://seekingalpha.com/news/3682098-regulus-therapeutics-completes-dosing-in-early-stage-kidney-disease-trial )
...
```
By default a single page of articles is fetched, using `-p` additional pages may be retrieved.
User can use the URL in the output to get a hold of the article in the web browser.


User can also use the `news_article` command with the ID of the article to see the article in the GST console.
For example:
```
(✨) (disc)> news_article -i 3682045
2021-04-15T07:42:24-04:00 Dollar Tree launches retail media network to connect brands
 Dollar Tree (NASDAQ:DLTR) introduces a new retail media network called Chesapeake Media Group.
Chesapeake Media is described as an innovative platform for brands to engage with their customers in a personalized and ultra-targeted digital experience, with a benefit of offering brands the ability to instantly connect with shoppers.
The company's Family Dollar brand also announced its partnerships with Swiftly and Aki Technologies to support the new digital platform, which offers consumer packaged goods Brand partners with fully-managed services through ad placements on the refreshed Family Dollar mobile app and website.
"Brands will be able to directly reach millions of families across America through a variety of digital options made possible through our newly-formed retail media network, Chesapeake Media Group, powered by Swiftly and Aki," says Dollar Tree Enterprise Chief Merchandising Officer Richard McNeely,.
DLTR  +0.20% premarket to  $115.13.
Read more details on the retail media network
```

The news articles are not filtered by the ticker, hence this can be used without loading any stock data first.

In addition, there is also a _trending_ widget seen on the original SA page that I could fetch the data from and show to the user, through a separate command.

I haven't paid much attention to the output formatting, as I'm not sure if this contribution would be accepted. Let me know if you want me to polish this PR further.