### PR TITLE
introduce latest ratings changes from MarketBeat

### DIFF
--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -20,6 +20,7 @@ from gamestonk_terminal.discovery import (
     spachero_view,
     unusual_whales_view,
     yahoo_finance_view,
+    marketbeat_view,
 )
 
 
@@ -46,6 +47,7 @@ class DiscoveryController:
         "valuation",
         "performance",
         "spectrum",
+        "ratings",
     ]
 
     def __init__(self):
@@ -87,6 +89,7 @@ class DiscoveryController:
         print("   valuation      valuation of sectors, industry, country [Finviz]")
         print("   performance    performance of sectors, industry, country [Finviz]")
         print("   spectrum       spectrum of sectors, industry, country [Finviz]")
+        print("   ratings        latest ratings [MarketBeat]")
         print("")
 
     def switch(self, an_input: str):
@@ -186,6 +189,10 @@ class DiscoveryController:
         self.spectrum_img_to_delete = finviz_view.view_group_data(
             other_args, "spectrum"
         )
+
+    def call_ratings(self, other_args: List[str]):
+        """Process ratings command"""
+        marketbeat_view.ratings_view(other_args)
 
 
 def menu():

--- a/gamestonk_terminal/discovery/marketbeat_model.py
+++ b/gamestonk_terminal/discovery/marketbeat_model.py
@@ -1,0 +1,93 @@
+""" MarketBeat Model """
+__docformat__ = "numpy"
+
+from typing import List
+import requests
+from bs4 import BeautifulSoup
+
+from gamestonk_terminal.helper_funcs import get_user_agent
+
+
+def get_ratings_html(url_ratings: str) -> str:
+    """Wraps HTTP requests.get for testibility
+
+    Parameters
+    ----------
+    url_ratings : str
+        Ratings URL
+
+    Returns
+    -------
+    str
+        HTML page of ratings
+    """
+    ratings_html = requests.get(
+        url_ratings, headers={"User-Agent": get_user_agent()}
+    ).text
+
+    return ratings_html
+
+
+def get_ratings() -> List[dict]:
+    """Returns a list of ratings
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    list
+        Ratings list
+    """
+
+    ratings = list()
+    url_ratings = "https://www.marketbeat.com/ratings/"
+
+    text_soup_ratings = BeautifulSoup(
+        get_ratings_html(url_ratings),
+        "lxml",
+    )
+
+    for stock_rows in text_soup_ratings.findAll("tr"):
+        tds = stock_rows.findAll("td")
+        if len(tds) == 8:
+            rating = {}
+            # company
+            td = tds[0]
+            company = td.find("div", {"class": "title-area"}).text
+            ticker = td.find("div", {"class": "ticker-area"}).text
+            rating["company"] = company
+            rating["ticker"] = ticker
+            # action
+            td = tds[1]
+            action = td.text
+            rating["action"] = action
+            # brokerage
+            td = tds[2]
+            brokerage = td.find("a").text
+            rating["brokerage"] = brokerage
+            # current price
+            td = tds[3]
+            if td.find("span"):
+                td.span.extract()
+            current_price = td.text
+            rating["current_price"] = current_price
+            # target price
+            td = tds[4]
+            target_price = td.text
+            rating["target_price"] = target_price
+            # new rating
+            td = tds[5]
+            new_rating = td.text
+            rating["rating"] = new_rating
+            # impact on price
+            td = tds[6]
+            if td.find("a"):
+                impact = td.find("a").text
+            else:
+                impact = td.text
+            rating["impact"] = impact
+            ratings.append(rating)
+
+    return ratings

--- a/gamestonk_terminal/discovery/marketbeat_view.py
+++ b/gamestonk_terminal/discovery/marketbeat_view.py
@@ -1,0 +1,54 @@
+""" MarketBeat View """
+__docformat__ = "numpy"
+
+import argparse
+from typing import List
+from gamestonk_terminal.helper_funcs import (
+    check_positive,
+    parse_known_args_and_warn,
+)
+
+from gamestonk_terminal.discovery import marketbeat_model
+
+
+def ratings_view(other_args: List[str]):
+    """Prints a list with ratings
+
+    Parameters
+    ----------
+    other_args : List[str]
+        argparse other args - ["-n", "5"]
+    """
+
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog="ratings",
+        description="""Latest ratings. [Source: MarketBeat]""",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--num",
+        action="store",
+        dest="n_num",
+        type=check_positive,
+        default=10,
+        help="number of ratings to print",
+    )
+
+    ns_parser = parse_known_args_and_warn(parser, other_args)
+    if not ns_parser:
+        return
+
+    ratings = marketbeat_model.get_ratings()
+    for idx, rating in enumerate(ratings):
+        print(
+            rating["ticker"],
+            rating["action"].replace(" by", ""),
+            rating["impact"],
+            rating["current_price"],
+            "->",
+            rating["target_price"],
+        )
+        if idx >= ns_parser.n_num - 1:
+            break


### PR DESCRIPTION
It might be interesting to see how the stock's ratings change. TBH, I'm not really looking at this data myself, I just wanted to gain some practice in adding new features/commands to GST :rofl: .

MarketBeat has a page that shows this https://www.marketbeat.com/ratings/.

I've added a new entry to discovery menu, called 'ratings'.
```
   ratings        latest ratings [MarketBeat]
```

It lists the entries scrapped from the above web page. No filters are applied, ATM. Example output:
```
(✨) (disc)> ratings
AA  Target Raised Medium $32.84 -> $36.00 ➝ $38.00
AAWW  Initiated Low $65.71 ->  $95.00
ACVA  Initiated Low $36.83 ->  $34.00
ADS  Target Set N/A €277.55 ->  €300.00
AEO  Target Raised Low $34.33 -> $25.00 ➝ $27.00
AFRM  Upgraded Medium $68.67 ->  $80.00
AIR  Target Set N/A €102.84 ->  €110.00
AIR  Target Set N/A €102.84 ->  €125.00
ALL  Target Raised Low $121.59 -> $119.00 ➝ $128.00
ALV  Target Set N/A €215.45 ->  €250.00
```

Formatting is not optimal and not all columns seen on the web page are printed (they are scrapped and available for printing, though).

BTW, It might be possible to add per-ticker filtered ratings command to only look up the ratings for the loaded ticker. Thoughts?

Comments welcomed!