### PR TITLE
Improve seekingalpha news

### DIFF
--- a/gamestonk_terminal/discovery/README.md
+++ b/gamestonk_terminal/discovery/README.md
@@ -229,12 +229,13 @@ Spectrum of sectors, industry, country. [Source: Finviz]
 ## latest <a name="latest"></a>
 
 ```
-usage: latest [-i N_ID] [-n N_NUM]
+usage: latest [-i N_ID] [-n N_NUM] [-d DATE]
 ```
 
 Latest news articles. [Source: Seeking Alpha]
-* -i : article number found on Seeking Alpha website
-* -n : number of latest articles being printed. Default 10.
+* -i : Article ID number.
+* -n : Number of articles being printed. Default 10.
+* -d : Date of news article.
 
 <img width="1208" alt="latest" src="https://user-images.githubusercontent.com/25267873/115089633-926c6a00-9f0a-11eb-9d0e-1eedfd8ba7ce.png">
 
@@ -246,8 +247,8 @@ usage: trending [-i N_ID] [-n N_NUM]
 ```
 
 Trending news articles. [Source: Seeking Alpha]
-* -i : article number found on Seeking Alpha website
-* -n : number of trending articles being printed. Default 10.
+* -i : Article ID number.
+* -n : Number of articles being printed. Default 10.
 
 <img width="1213" alt="trending" src="https://user-images.githubusercontent.com/25267873/115089640-96988780-9f0a-11eb-9ca7-70a245fa3960.png">
 

--- a/gamestonk_terminal/discovery/seeking_alpha_model.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_model.py
@@ -91,12 +91,14 @@ def get_articles_html(url_articles: str) -> str:
     return articles_html
 
 
-def get_article_list(num: int) -> List[dict]:
+def get_article_list(start_date: datetime, num: int) -> List[dict]:
     """Returns a list of latest articles
 
     Parameters
     ----------
-    pages : int
+    start_date : datetime
+        Starting date
+    num : int
         Number of articles
 
     Returns
@@ -122,13 +124,15 @@ def get_article_list(num: int) -> List[dict]:
             if not article_url.startswith("/news/"):
                 continue
             article_id = article_url.split("/")[2].split("-")[0]
-
+            article_date = datetime.strptime(
+                item_row["data-last-date"], "%Y-%m-%d %H:%M:%S %z"
+            )
+            if start_date.date() < article_date.date():
+                continue
             articles.append(
                 {
                     "title": item.text,
-                    "publishedAt": datetime.strptime(
-                        item_row["data-last-date"], "%Y-%m-%d %H:%M:%S %z"
-                    ).strftime("%Y-%m-%d %H:%M:%S"),
+                    "publishedAt": article_date.strftime("%Y-%m-%d %H:%M:%S"),
                     "url": "https://seekingalpha.com" + article_url,
                     "id": article_id,
                 }

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -89,7 +89,7 @@ def latest_news_view(other_args: List[str]):
         dest="n_id",
         type=check_positive,
         default=-1,
-        help="article number found on Seeking Alpha website",
+        help="article ID number",
     )
     parser.add_argument(
         "-n",
@@ -98,7 +98,7 @@ def latest_news_view(other_args: List[str]):
         dest="n_num",
         type=check_positive,
         default=10,
-        help="number of latest articles being printed",
+        help="number of articles being printed",
     )
     parser.add_argument(
         "-d",
@@ -107,7 +107,7 @@ def latest_news_view(other_args: List[str]):
         dest="n_date",
         type=valid_date,
         default=datetime.now().strftime("%Y-%m-%d"),
-        help="starting date of latest articles being printed",
+        help="starting date",
     )
 
     if other_args:
@@ -172,7 +172,7 @@ def trending_news_view(other_args: List[str]):
         dest="n_id",
         type=check_positive,
         default=-1,
-        help="article number found on Seeking Alpha website",
+        help="article ID number",
     )
     parser.add_argument(
         "-n",
@@ -181,7 +181,7 @@ def trending_news_view(other_args: List[str]):
         dest="n_num",
         type=check_positive,
         default=10,
-        help="number of trending articles being printed",
+        help="number of articles being printed",
     )
 
     if other_args:

--- a/gamestonk_terminal/discovery/seeking_alpha_view.py
+++ b/gamestonk_terminal/discovery/seeking_alpha_view.py
@@ -4,9 +4,11 @@ __docformat__ = "numpy"
 import argparse
 from typing import List
 import pandas as pd
+from datetime import datetime
 from gamestonk_terminal.helper_funcs import (
     check_positive,
     parse_known_args_and_warn,
+    valid_date,
 )
 
 from gamestonk_terminal.discovery import seeking_alpha_model
@@ -98,6 +100,15 @@ def latest_news_view(other_args: List[str]):
         default=10,
         help="number of latest articles being printed",
     )
+    parser.add_argument(
+        "-d",
+        "--date",
+        action="store",
+        dest="n_date",
+        type=valid_date,
+        default=datetime.now().strftime("%Y-%m-%d"),
+        help="starting date of latest articles being printed",
+    )
 
     if other_args:
         if "-" not in other_args[0]:
@@ -109,7 +120,9 @@ def latest_news_view(other_args: List[str]):
 
     # User wants to see all latest news
     if ns_parser.n_id == -1:
-        articles = seeking_alpha_model.get_article_list(ns_parser.n_num)
+        articles = seeking_alpha_model.get_article_list(
+            ns_parser.n_date, ns_parser.n_num
+        )
         for idx, article in enumerate(articles):
             print(
                 article["publishedAt"].replace("T", " ").replace("Z", ""),


### PR DESCRIPTION
User can specify the starting date of the articles to print for `latest` command.

```
(✨) (disc)> latest -h
usage: latest [-i N_ID] [-n N_NUM] [-d N_DATE] [-h]

Latest news articles. [Source: Seeking Alpha]

optional arguments:
  -i N_ID, --id N_ID    article ID number
  -n N_NUM, --num N_NUM
                        number of articles being printed
  -d N_DATE, --date N_DATE
                        starting date
  -h, --help            show this help message
```

Today/Latest:

```
(✨) (disc)> latest -n 3
2021-04-17 12:53:25 - 3682747 - Goldman, Morgan Stanley signal plans for crypto ‘disruption’: Alpha Tactics
https://seekingalpha.com/news/3682747-goldman-morgan-stanley-signal-plans-for-crypto-disruption-alpha-tact

2021-04-17 11:21:31 - 3682759 - Apple could launch new iPad Pro, iMac models at Spring Loaded event
https://seekingalpha.com/news/3682759-apple-could-launch-new-ipad-pro-imac-models-at-spring-loaded-event

2021-04-17 08:53:41 - 3682758 - Peloton in talks with CPSC on treadmill warning
https://seekingalpha.com/news/3682758-peloton-in-talks-with-cpsc-on-treadmill-warning
```

Starting on user supplied date (15 Apr 2021).

```
(✨) (disc)> latest -n 3 -d 2021-04-15
2021-04-15 23:57:19 - 3682451 - Bally's prices equity offering at $55
https://seekingalpha.com/news/3682451-ballys-prices-equity-offering-at-55

2021-04-15 23:47:11 - 3682448 - NexTech AR Solutions reports FY results
https://seekingalpha.com/news/3682448-nextech-ar-solutions-reports-fy-results

2021-04-15 23:24:55 - 3682440 - Targa Resources declares $0.10 dividend
https://seekingalpha.com/news/3682440-targa-resources-declares-0_10-dividend
```

Notice that the articles are in descending order (as seen on the webpage). In case user provides a starting date the first article printed is in fact the last one posted that day. Is this OK?