### PR TITLE
Add vega, gamma and theta to option chains display

### DIFF
--- a/gamestonk_terminal/options/chains_view.py
+++ b/gamestonk_terminal/options/chains_view.py
@@ -129,7 +129,9 @@ def display_chains(symbol: str, expiry: str, other_args: List[str]):
 
     default_columns = [
         "mid_iv",
+        "vega",
         "delta",
+        "gamma",
         "volume",
         "open_interest",
         "bid",

--- a/gamestonk_terminal/options/chains_view.py
+++ b/gamestonk_terminal/options/chains_view.py
@@ -132,6 +132,7 @@ def display_chains(symbol: str, expiry: str, other_args: List[str]):
         "vega",
         "delta",
         "gamma",
+        "theta",
         "volume",
         "open_interest",
         "bid",


### PR DESCRIPTION
Nice to have vega and gamma aslo displayed in the options chain, as these greeks are quite important when making choices.