### PR TITLE
Add a hint on adding the reddit api credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Environment variables can also be set in a `.env` file at the top of the repo. T
 GT_API_REDDIT_USERNAME=SexyYear
 ```
 
+Note that the `GT_API_REDDIT_USER_AGENT` is the name of the script that you set when obtained the Reddit API key.
 Note that it is not necessary to have a valid Alpha Vantage key to get daily OHLC values.
 
 ### Usage


### PR DESCRIPTION
This is a small note addition to the readme on 
![image](https://user-images.githubusercontent.com/11668535/116008378-e0752200-a61c-11eb-973e-d8ba25d9aca6.png)
 following a request from discord chat