### PR TITLE
Add sphinx based documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+---
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally set the version of Python and requirements to build your docs
+python:
+   version: 3.7
+   install:
+      - requirements: requirements-full.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -1,0 +1,318 @@
+Class library and code comments
+======================================
+
+Root level files
+----------------------------------
+
+.. automodule:: gamestonk_terminal.feature_flags
+   :members:
+.. automodule:: gamestonk_terminal.helper_funcs
+   :members:
+.. automodule:: gamestonk_terminal.main_helper
+   :members:
+.. automodule:: gamestonk_terminal.menu
+   :members:
+.. automodule:: gamestonk_terminal.reddit_helpers
+   :members:
+.. automodule:: gamestonk_terminal.res_menu
+   :members:
+.. automodule:: gamestonk_terminal.test_helper
+   :members:
+.. automodule:: gamestonk_terminal.thought_of_the_day
+   :members:
+.. automodule:: gamestonk_terminal.config_neural_network_models
+   :members:
+.. automodule:: gamestonk_terminal.config_plot
+   :members:
+.. automodule:: gamestonk_terminal.config_terminal
+   :members:
+.. automodule:: gamestonk_terminal.dataframe_helpers
+   :members:
+
+
+Technical analysis
+-------------------
+
+.. automodule:: gamestonk_terminal.technical_analysis.finbrain_view
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.finviz_view
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.momentum
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.overlap
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.ta_controller
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.tradingview_view
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.trend_indicators
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.trendline_api
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.volatility
+   :members:
+.. automodule:: gamestonk_terminal.technical_analysis.volume
+   :members:
+
+
+Stock screener
+--------------
+
+.. automodule:: gamestonk_terminal.screener.finviz_view
+   :members:
+.. automodule:: gamestonk_terminal.screener.screener_controller
+   :members:
+.. automodule:: gamestonk_terminal.screener.yahoo_finance_view
+   :members:
+
+
+Residual analysis
+-----------------
+
+.. automodule:: gamestonk_terminal.residuals_analysis.ra_controller
+   :members:
+.. automodule:: gamestonk_terminal.residuals_analysis.residuals_api
+   :members:
+.. automodule:: gamestonk_terminal.residuals_analysis.residuals_model
+   :members:
+
+
+Prediction techniques
+---------------------
+
+.. automodule:: gamestonk_terminal.prediction_techniques.arima
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.ets
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.fbprophet
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.knn
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.neural_networks
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.pred_controller
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.pred_helper
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.regression
+   :members:
+.. automodule:: gamestonk_terminal.prediction_techniques.sma
+   :members:
+
+
+Portfolio optimization
+----------------------
+
+.. automodule:: gamestonk_terminal.portfolio_optimization.optimizer_helper
+   :members:
+.. automodule:: gamestonk_terminal.portfolio_optimization.optimizer_view
+   :members:
+.. automodule:: gamestonk_terminal.portfolio_optimization.po_controller
+   :members:
+
+
+
+Behavioural analysis
+--------------------
+
+.. automodule:: gamestonk_terminal.behavioural_analysis.ba_controller
+   :members:
+.. automodule:: gamestonk_terminal.behavioural_analysis.finbrain_view
+   :members:
+.. automodule:: gamestonk_terminal.behavioural_analysis.google_view
+   :members:
+.. automodule:: gamestonk_terminal.behavioural_analysis.reddit_view
+   :members:
+.. automodule:: gamestonk_terminal.behavioural_analysis.stocktwits_view
+   :members:
+.. automodule:: gamestonk_terminal.behavioural_analysis.twitter_view
+   :members:
+
+Comparison analysis
+--------------------
+
+.. automodule:: gamestonk_terminal.comparison_analysis.ca_controller
+   :members:
+.. automodule:: gamestonk_terminal.comparison_analysis.finbrain_view
+   :members:
+.. automodule:: gamestonk_terminal.comparison_analysis.finviz_compare_view
+   :members:
+.. automodule:: gamestonk_terminal.comparison_analysis.market_watch_view
+   :members:
+.. automodule:: gamestonk_terminal.comparison_analysis.yahoo_finance_view
+   :members:
+
+
+Cryptocurrency
+--------------
+
+.. automodule:: gamestonk_terminal.cryptocurrency.coinmarketcap_view
+   :members:
+.. automodule:: gamestonk_terminal.cryptocurrency.crypto_controller
+   :members:
+.. automodule:: gamestonk_terminal.cryptocurrency.crypto_helper
+   :members:
+
+
+Discovery
+---------
+
+.. automodule:: gamestonk_terminal.discovery.alpha_vantage_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.ark_model
+   :members:
+.. automodule:: gamestonk_terminal.discovery.ark_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.disc_controller
+   :members:
+.. automodule:: gamestonk_terminal.discovery.fidelity_model
+   :members:
+.. automodule:: gamestonk_terminal.discovery.fidelity_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.finra_ats_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.finviz_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.marketbeat_model
+   :members:
+.. automodule:: gamestonk_terminal.discovery.marketbeat_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.seeking_alpha_model
+   :members:
+.. automodule:: gamestonk_terminal.discovery.seeking_alpha_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.short_interest_model
+   :members:
+.. automodule:: gamestonk_terminal.discovery.short_interest_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.simply_wallst_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.spachero_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.unusual_whales_view
+   :members:
+.. automodule:: gamestonk_terminal.discovery.yahoo_finance_view
+   :members:
+
+Due diligence
+-------------
+
+.. automodule:: gamestonk_terminal.due_diligence.business_insider_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.dd_controller
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.financial_modeling_prep_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.finra_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.finviz_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.market_watch_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.news_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.quandl_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.reddit_view
+   :members:
+.. automodule:: gamestonk_terminal.due_diligence.sec_view
+   :members:
+
+Econ
+-----
+
+.. automodule:: gamestonk_terminal.econ.econ_controller
+   :members:
+.. automodule:: gamestonk_terminal.econ.fred_view
+   :members:
+.. automodule:: gamestonk_terminal.econ.vix_view
+   :members:
+
+Exploratory data analysis
+-------------------------
+
+.. automodule:: gamestonk_terminal.exploratory_data_analysis.eda_api
+   :members:
+.. automodule:: gamestonk_terminal.exploratory_data_analysis.eda_controller
+   :members:
+
+Forex
+-----
+
+.. automodule:: gamestonk_terminal.forex.fx_controller
+   :members:
+.. automodule:: gamestonk_terminal.forex.fx_view
+   :members:
+
+Fundamental analysis
+--------------------
+
+.. automodule:: gamestonk_terminal.fundamental_analysis.alpha_vantage_controller
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.alpha_vantage_view
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.business_insider_view
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.fa_controller
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.financial_modeling_prep_controller
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.financial_modeling_prep_view
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.finviz_view
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.market_watch_model
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.market_watch_view
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.yahoo_finance_view
+   :members:
+.. automodule:: gamestonk_terminal.fundamental_analysis.yield_curve_model
+   :members:
+
+Options
+-------
+
+.. automodule:: gamestonk_terminal.options.chains_view
+   :members:
+.. automodule:: gamestonk_terminal.options.op_controller
+   :members:
+.. automodule:: gamestonk_terminal.options.op_scrape_view
+   :members:
+.. automodule:: gamestonk_terminal.options.volume_helper
+   :members:
+.. automodule:: gamestonk_terminal.options.volume_view
+   :members:
+
+Papermill
+---------
+
+.. automodule:: gamestonk_terminal.papermill.due_diligence_view
+   :members:
+.. automodule:: gamestonk_terminal.papermill.econ_data_helper
+   :members:
+.. automodule:: gamestonk_terminal.papermill.econ_data_view
+   :members:
+.. automodule:: gamestonk_terminal.papermill.papermill_controller
+   :members:
+
+Portfolio
+----------
+
+.. automodule:: gamestonk_terminal.portfolio.ally_api
+   :members:
+.. automodule:: gamestonk_terminal.portfolio.alp_api
+   :members:
+.. automodule:: gamestonk_terminal.portfolio.dg_api
+   :members:
+.. automodule:: gamestonk_terminal.portfolio.port_controller
+   :members:
+.. automodule:: gamestonk_terminal.portfolio.portfolio_helpers
+   :members:
+.. automodule:: gamestonk_terminal.portfolio.rh_api
+   :members:
+
+
+
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+import sphinx_rtd_theme
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.join(os.path.abspath('.'), '..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Gamestonk Terminal'
+copyright = '2021, Gamestonk Terminal Contributors'
+author = 'Gamestonk Terminal Contributors'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['myst_parser',
+              'sphinx.ext.autodoc',
+              'sphinx.ext.napoleon',
+              'sphinx.ext.viewcode',
+              'sphinx_rtd_theme'
+              ]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,36 +13,38 @@
 import os
 import sys
 import sphinx_rtd_theme
-sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.join(os.path.abspath('.'), '..'))
+
+sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.join(os.path.abspath("."), ".."))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'Gamestonk Terminal'
-copyright = '2021, Gamestonk Terminal Contributors'
-author = 'Gamestonk Terminal Contributors'
+project = "Gamestonk Terminal"
+copyright = "2021, Gamestonk Terminal Contributors"
+author = "Gamestonk Terminal Contributors"
 
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
-extensions = ['myst_parser',
-              'sphinx.ext.autodoc',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.viewcode',
-              'sphinx_rtd_theme'
-              ]
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx_rtd_theme",
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -50,9 +52,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 #
 import os
 import sys
-import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.join(os.path.abspath("."), ".."))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,21 @@
+.. Gamestonk Terminal documentation master file, created by
+   sphinx-quickstart on Thu Apr 29 21:54:05 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Gamestonk Terminal's documentation!
+==============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   code
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+myst-parser
+sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-sphinx
-myst-parser
-sphinx-rtd-theme

--- a/gamestonk_terminal/forex/fx_controller.py
+++ b/gamestonk_terminal/forex/fx_controller.py
@@ -92,12 +92,13 @@ class ForexController:
 
     def switch(self, an_input: str):
         """Process and dispatch input
+
         Returns
-        ______
+        -------
         True, False, or None
-        False - quit the menu
-        True - quit the program
-        None - continue in the menu
+            False - quit the menu
+            True - quit the program
+            None - continue in the menu
         """
         (known_args, other_args) = self.fx_parser.parse_known_args(an_input.split())
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -222,3 +222,6 @@ yarl==1.6.3; python_version >= "3.6"
 yfinance==0.1.59
 zipp==3.4.1; python_version < "3.8" and python_version >= "3.6"
 zope.interface==5.4.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
+sphinx==3.5.4
+myst-parser==0.13.7
+sphinx-rtd-theme==0.5.2


### PR DESCRIPTION
The PR includes configuration files and text templates for building autogenerated documentation with Sphinx. This implementation uses the Read-the-docs theme. A yaml config is provided to enable automatic building of the documentation on readthedocs.io